### PR TITLE
feat :Added schema discounted amount in Purchase invoice & calculated total

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -1,0 +1,13 @@
+frappe.ui.form.on('Purchase Invoice Item', {
+    schema_discount_amount: function(frm) {
+        let total = 0;
+        frm.doc.items.forEach(function(row) {
+            if (row.schema_discount_amount) {
+                total += row.schema_discount_amount;
+            }
+        });
+        frm.set_value('schema_discount_amount', total);
+    }
+});
+
+

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -1,19 +1,5 @@
-
-function update_schema_discount_amount_total(frm) {
-    let total = 0;
-    (frm.doc.items || []).forEach(row => {
-        if (row.schema_discount_amount) {
-            total += row.schema_discount_amount;
-        }
-    });
-    frm.set_value('schema_discount_amount', total);
-}
-
-frappe.ui.form.on('Purchase Invoice Item', {
-    schema_discount_amount: function(frm) {
-        update_schema_discount_amount_total(frm);
-    }
-});
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on('Purchase Invoice', {
     onload: function(frm) {
@@ -30,4 +16,20 @@ frappe.ui.form.on('Purchase Invoice', {
         });
     }
 });
+
+frappe.ui.form.on('Purchase Invoice Item', {
+    schema_discount_amount: function(frm) {
+        update_schema_discount_amount_total(frm);
+    }
+});
+
+function update_schema_discount_amount_total(frm) {
+    let total = 0;
+    (frm.doc.items || []).forEach(row => {
+        if (row.schema_discount_amount) {
+            total += row.schema_discount_amount;
+        }
+    });
+    frm.set_value('schema_discount_amount', total);
+}
 

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -23,6 +23,9 @@ frappe.ui.form.on('Purchase Invoice Item', {
     }
 });
 
+/**
+ * function to calculate the total of schema discount amount from items table
+ */
 function update_schema_discount_amount_total(frm) {
     let total = 0;
     (frm.doc.items || []).forEach(row => {

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -1,13 +1,33 @@
+
+function update_schema_discount_amount_total(frm) {
+    let total = 0;
+    (frm.doc.items || []).forEach(row => {
+        if (row.schema_discount_amount) {
+            total += row.schema_discount_amount;
+        }
+    });
+    frm.set_value('schema_discount_amount', total);
+}
+
 frappe.ui.form.on('Purchase Invoice Item', {
     schema_discount_amount: function(frm) {
-        let total = 0;
-        frm.doc.items.forEach(function(row) {
-            if (row.schema_discount_amount) {
-                total += row.schema_discount_amount;
-            }
-        });
-        frm.set_value('schema_discount_amount', total);
+        update_schema_discount_amount_total(frm);
     }
 });
 
+frappe.ui.form.on('Purchase Invoice', {
+    onload: function(frm) {
+        let previous_length = frm.doc.items ? frm.doc.items.length : 0;
+
+        frm.fields_dict.items.grid.wrapper.on('click', function() {
+            setTimeout(() => {
+                let current_length = frm.doc.items ? frm.doc.items.length : 0;
+                if (current_length !== previous_length) {
+                    update_schema_discount_amount_total(frm);
+                    previous_length = current_length;
+                }
+            }, 150);
+        });
+    }
+});
 

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
 import frappe
 
 def update_schema_discount_amount(doc, method):

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -1,0 +1,13 @@
+import frappe
+
+def update_schema_discount_amount(doc, method):
+    """
+    Updates the parent schema_discount_amount field with the sum of all child schema_discount_amount values.
+    """
+    total_schema_discount = 0
+
+    for item in doc.items:
+        if item.schema_discount_amount:
+            total_schema_discount += item.schema_discount_amount
+
+    doc.schema_discount_amount = total_schema_discount

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -144,8 +144,8 @@ doc_events = {
     "Purchase Receipt": {
         "before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"
     },
-	"Purchase Invoice": {
-        "validate": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount"
+    "Purchase Invoice": {
+        "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount"
     }
 }
 

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -43,7 +43,7 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {"Purchase Invoice" : "e_mart/custom_scripts/purchase_invoice/purchase_invoice.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -143,6 +143,9 @@ doc_events = {
     },
     "Purchase Receipt": {
         "before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"
+    },
+	"Purchase Invoice": {
+        "validate": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount"
     }
 }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -12,6 +12,7 @@ def after_install():
     create_custom_fields(get_sales_order_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_purchase_invoice_item_custom_fields(),ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -25,6 +26,7 @@ def before_uninstall():
     delete_custom_fields(get_sales_order_item_custom_fields())
     delete_custom_fields(get_sales_invoice_item_custom_fields())
     delete_custom_fields(get_serial_and_batch_entry_custom_fields())
+    delete_custom_fields(get_purchase_invoice_item_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -87,6 +89,34 @@ def get_purchase_invoice_custom_fields():
                 "label": "Purchase Category",
                 "options": "Normal\nSpecial",
                 "insert_after": "apply_tds"
+            },
+            {
+                "fieldname": "purchase_schema",
+                "fieldtype": "Select",
+                "label": "Purchase Schema",
+                "options": "Item-Wise\nInvoice-level",
+                "insert_after": "supplier"
+			},
+            {
+                "fieldname": "schema_discount_amount",
+                "fieldtype": "Currency",
+                "label": "Schema Discount Amount",
+                "insert_after": "items"
+			},
+        ]
+    }
+
+def get_purchase_invoice_item_custom_fields():
+    """
+    Custom fields that need to be added to the Purchase Invoice Item DocType
+    """
+    return {
+        "Purchase Invoice Item": [   
+            {
+                "fieldname": "schema_discount_amount",
+                "fieldtype": "Currency",
+                "label": "Schema Discount Amount",
+                "insert_after": "amount"  
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Created two fields in purchase invoice through setup.
If purchase schema is item-wise it should be read only other wise editable
Purchase invoice doctype there is a items table inside that there is field schema discount amount and total discount should be shown in schema discount amount . 
When edited the schema discount amount it need to change the total before saving it.
When deleted a row the schema discount amount should be deducted.

## Solution description
Created field called purchase schema with options item wise and invoice level
Created field schema discount amount inside the child table and outside the table
Schema discount amount calculated on the basis of child table sum.
If the purchase schema is invoice level it can be edited others is read only

## Output
![Screenshot from 2025-06-28 20-02-52](https://github.com/user-attachments/assets/b10570c0-828c-4e02-8f18-7fc5655c48a5)
![Screenshot from 2025-06-28 20-05-07](https://github.com/user-attachments/assets/5ec4ed5b-c61e-4620-88b7-eb807307e7b9)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Chrome