### PR TITLE
feat:added fields in item doctype and lavanya settings

### DIFF
--- a/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.js
+++ b/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Lavanya Emart Settings", {
+// frappe.ui.form.on("E-mart Settings", {
 // 	refresh(frm) {
 
 // 	},

--- a/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
+++ b/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
@@ -44,9 +44,9 @@
  "issingle": 1,
  "links": [],
  "modified": "2025-06-30 13:28:21.836463",
- "modified_by": "administrator@example.com",
+ "modified_by": "Administrator",
  "module": "E Mart",
- "name": "Lavanya Emart Settings",
+ "name": "E-mart Settings",
  "owner": "Administrator",
  "permissions": [
   {

--- a/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.py
+++ b/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.py
@@ -5,5 +5,5 @@
 from frappe.model.document import Document
 
 
-class LavanyaEmartSettings(Document):
+class EmartSettings(Document):
 	pass

--- a/e_mart/e_mart/doctype/e_mart_settings/test_e_mart_settings.py
+++ b/e_mart/e_mart/doctype/e_mart_settings/test_e_mart_settings.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestLavanyaEmartSettings(FrappeTestCase):
+class TestE-martSettings(FrappeTestCase):
 	pass

--- a/e_mart/e_mart/doctype/lavanya_emart_settings/lavanya_emart_settings.json
+++ b/e_mart/e_mart/doctype/lavanya_emart_settings/lavanya_emart_settings.json
@@ -6,7 +6,10 @@
  "engine": "InnoDB",
  "field_order": [
   "purchase_series_mapping",
-  "debit_note_adjusted_account"
+  "section_break_ecmj",
+  "debit_note_adjusted_account",
+  "column_break_nwjy",
+  "scrap_warehouse"
  ],
  "fields": [
   {
@@ -20,14 +23,28 @@
    "fieldtype": "Link",
    "label": "Debit Note Adjusted Account",
    "options": "Account"
+  },
+  {
+   "fieldname": "section_break_ecmj",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_nwjy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "scrap_warehouse",
+   "fieldtype": "Link",
+   "label": "Scrap Warehouse",
+   "options": "Warehouse"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-06-27 10:16:42.884342",
- "modified_by": "Administrator",
+ "modified": "2025-06-30 13:28:21.836463",
+ "modified_by": "administrator@example.com",
  "module": "E Mart",
  "name": "Lavanya Emart Settings",
  "owner": "Administrator",
@@ -43,6 +60,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -187,7 +187,6 @@ def get_customer_custom_fields():
         ]
     }
 
-
 def get_sales_order_item_custom_fields():
     """
     Custom fields that need to be added to the Sales Order Item DocType

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -13,6 +13,7 @@ def after_install():
     create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_purchase_invoice_item_custom_fields(),ignore_validate=True, update=True)
+    create_custom_fields(get_item_custom_fields(),ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -27,6 +28,7 @@ def before_uninstall():
     delete_custom_fields(get_sales_invoice_item_custom_fields())
     delete_custom_fields(get_serial_and_batch_entry_custom_fields())
     delete_custom_fields(get_purchase_invoice_item_custom_fields())
+    delete_custom_fields(get_item_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -118,6 +120,46 @@ def get_purchase_invoice_item_custom_fields():
                 "label": "Schema Discount Amount",
                 "insert_after": "amount"  
             }
+        ]
+    }
+
+def get_item_custom_fields():
+    """
+    Custom fields that need to be added to the Item DocType
+    """
+    return {
+        "Item": [
+            {
+                "fieldname": "type_of_commission",
+                "fieldtype": "Select",
+                "label": "Type Of Commission",
+                "options": "Percentage\nFixed",
+                "insert_after": "stock_uom"
+            },
+            {
+                "fieldname": "commission_value",
+                "fieldtype": "Float",
+                "label": "Commission Value",
+                "insert_after": "type_of_commission"
+			},
+            {
+                "fieldname": "demo_required",
+                "fieldtype": "Check",
+                "label": "Demo Required",
+                "insert_after": "commission_value"
+			},
+            {
+                "fieldname": "periodic_service",
+                "fieldtype": "Check",
+                "label": "Periodic Service",
+                "insert_after": "demo_required"
+			},
+            {
+                "fieldname": "mrp",
+                "fieldtype": "Float",
+                "label": "MRP",
+                "insert_after": "periodic_service"
+			},
         ]
     }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -100,13 +100,13 @@ def get_purchase_invoice_custom_fields():
                 "label": "Purchase Schema",
                 "options": "Item-Wise\nInvoice-level",
                 "insert_after": "supplier"
-			},
+            },
             {
                 "fieldname": "schema_discount_amount",
                 "fieldtype": "Currency",
                 "label": "Schema Discount Amount",
                 "insert_after": "items"
-			},
+            },
         ]
     }
 
@@ -143,25 +143,25 @@ def get_item_custom_fields():
                 "fieldtype": "Float",
                 "label": "Commission Value",
                 "insert_after": "type_of_commission"
-			},
+            },
             {
                 "fieldname": "demo_required",
                 "fieldtype": "Check",
                 "label": "Demo Required",
                 "insert_after": "commission_value"
-			},
+            },
             {
                 "fieldname": "periodic_service",
                 "fieldtype": "Check",
                 "label": "Periodic Service",
                 "insert_after": "demo_required"
-			},
+            },
             {
                 "fieldname": "mrp",
                 "fieldtype": "Float",
                 "label": "MRP",
                 "insert_after": "periodic_service"
-			},
+            },
         ]
     }
 
@@ -182,7 +182,7 @@ def get_customer_custom_fields():
                 "fieldtype": "Date",
                 "label": "EMI Start Date",
                 "insert_after": "is_provider"
-			}
+            }
         ]
     }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -14,6 +14,7 @@ def after_install():
     create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_purchase_invoice_item_custom_fields(),ignore_validate=True, update=True)
     create_custom_fields(get_item_custom_fields(),ignore_validate=True, update=True)
+    create_custom_fields(get_customer_custom_fields(),ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -29,6 +30,7 @@ def before_uninstall():
     delete_custom_fields(get_serial_and_batch_entry_custom_fields())
     delete_custom_fields(get_purchase_invoice_item_custom_fields())
     delete_custom_fields(get_item_custom_fields())
+    delete_custom_fields(get_customer_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -162,6 +164,28 @@ def get_item_custom_fields():
 			},
         ]
     }
+
+def get_customer_custom_fields():
+    """
+    Custom fields that need to be added to the Customer DocType
+    """
+    return {
+        "Customer": [
+            {
+                "fieldname": "is_provider",
+                "fieldtype": "Check",
+                "label": "Is Provider",
+                "insert_after": "customer_group"
+            },
+            {
+                "fieldname": "emi_start_date",
+                "fieldtype": "Date",
+                "label": "EMI Start Date",
+                "insert_after": "is_provider"
+			}
+        ]
+    }
+
 
 def get_sales_order_item_custom_fields():
     """


### PR DESCRIPTION
## Feature description
Added fields in item doctype through setup the fields are Type of Commission,Commission Value,
Demo Required,Periodic,MRP
Created field in Lavanya Emart Settings called scrap warehouse
Added fields in customer doctype through setup the fields are Is provider(check box),EMI start date



## Solution description
created field in both items and Lavanya Emart Settings

## Output
![Screenshot from 2025-06-30 13-41-15](https://github.com/user-attachments/assets/938a11dc-a832-4623-81a1-8b8ecd189abe)
![Screenshot from 2025-06-30 13-40-55](https://github.com/user-attachments/assets/5cfc3874-8298-4994-9631-37e3111d5dc7)
![Screenshot from 2025-06-30 15-01-57](https://github.com/user-attachments/assets/7d93ec07-2bd9-4547-b73f-3fa5363e1d0a)


## Areas affected and ensured
-New feature

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Chrome