### PR TITLE
feat: Create Debit Note Log and Journal Entry

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -14,3 +14,37 @@ def update_schema_discount_amount(doc, method):
             total_schema_discount += item.schema_discount_amount
 
     doc.schema_discount_amount = total_schema_discount
+
+def on_submit(doc, method):
+    create_debit_note_log(doc)
+
+def create_debit_note_log(purchase_invoice):
+    '''
+        Creates a Debit Note Log from a submitted Purchase Invoice
+    '''
+    exists = frappe.db.exists("Debit Note Log", {"purchase_invoice": purchase_invoice.name})
+    if exists:
+        frappe.msgprint(f"Debit Note Log already exists for {purchase_invoice.name}")
+        return
+
+    # Create new Debit Note Log
+    dnl = frappe.new_doc("Debit Note Log")
+    dnl.supplier = purchase_invoice.supplier
+    dnl.purchase_invoice = purchase_invoice.name
+    dnl.purchase_schema = purchase_invoice.purchase_schema
+    dnl.status = "Pending"
+    dnl.total_invoice_amount = purchase_invoice.total
+    dnl.discounted_amount = purchase_invoice.schema_discount_amount
+
+    # Add items from Purchase Invoice
+    for item in purchase_invoice.items:
+        dnl.append("items", {
+            "item": item.item_code,
+            "item_name": item.item_name,
+            "quantity": item.qty,
+            "rate": item.rate,
+            "discount": item.schema_discount_amount
+        })
+
+    dnl.insert(ignore_permissions=True)
+    frappe.msgprint(f"Debit Note Log <a href='/app/debit-note-log/{dnl.name}'>{dnl.name}</a> created.")

--- a/e_mart/e_mart/doctype/debit_note_log/debit_note_log.json
+++ b/e_mart/e_mart/doctype/debit_note_log/debit_note_log.json
@@ -15,11 +15,16 @@
   "items",
   "section_break_omvk",
   "amended_from",
-  "supplier_credit_note_no",
-  "supplier_credit_note",
-  "column_break_adat",
   "total_invoice_amount",
+  "column_break_adat",
   "discounted_amount",
+  "section_break_lxyh",
+  "credit_note_details_column",
+  "supplier_credit_note_no",
+  "attach",
+  "column_break_ycsh",
+  "date",
+  "supplier_credit_note_amount",
   "references_section",
   "jv_reference"
  ],
@@ -63,6 +68,7 @@
    "search_index": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "jv_reference",
    "fieldtype": "Link",
    "label": "JV Reference",
@@ -76,11 +82,6 @@
   {
    "fieldname": "section_break_lsbc",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "supplier_credit_note",
-   "fieldtype": "Attach",
-   "label": "Supplier Credit Note"
   },
   {
    "fieldname": "column_break_adat",
@@ -113,13 +114,41 @@
    "fieldname": "references_section",
    "fieldtype": "Section Break",
    "label": "References"
+  },
+  {
+   "fieldname": "section_break_lxyh",
+   "fieldtype": "Section Break",
+   "label": "Credit Note Details"
+  },
+  {
+   "fieldname": "credit_note_details_column",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "attach",
+   "fieldtype": "Attach",
+   "label": "Attach"
+  },
+  {
+   "fieldname": "column_break_ycsh",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
+  },
+  {
+   "fieldname": "supplier_credit_note_amount",
+   "fieldtype": "Currency",
+   "label": "Supplier Credit Note Amount"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-27 11:04:41.344312",
+ "modified": "2025-06-27 12:28:32.656273",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "Debit Note Log",

--- a/e_mart/e_mart/doctype/debit_note_log/debit_note_log.py
+++ b/e_mart/e_mart/doctype/debit_note_log/debit_note_log.py
@@ -1,9 +1,70 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
-
 class DebitNoteLog(Document):
-	pass
+    def on_submit(self):
+        if self.workflow_state == "Approved":
+            self.create_journal_entry()
+
+    def create_journal_entry(self):
+        '''
+        Creates a Journal Entry for the discounted amount in the Debit Note Log
+        '''
+        if not self.discounted_amount or self.discounted_amount <= 0:
+            frappe.throw("Discounted Amount must be greater than 0.")
+
+        company = frappe.db.get_value("Purchase Invoice", self.purchase_invoice, "company")
+
+        if not company:
+            frappe.throw(f"Company not found for Purchase Invoice {self.purchase_invoice}")
+
+        supplier_account = frappe.db.get_value(
+            "Party Account",
+            {
+                "parent": self.supplier,
+                "parenttype": "Supplier",
+                "company": company
+            },
+            "account"
+        )
+
+        if not supplier_account:
+            frappe.throw(f"No account found for Supplier {self.supplier} in company {company}")
+
+        adjusted_account = frappe.db.get_single_value("Lavanya Emart Settings", "debit_note_adjusted_account")
+        if not adjusted_account:
+            frappe.throw("Please set 'Debit Note Adjusted Account' in Lavanya Emart Settings.")
+
+        # Create Journal Entry
+        je = frappe.new_doc("Journal Entry")
+        je.voucher_type = "Debit Note"
+        je.posting_date = frappe.utils.nowdate()
+        je.company = company
+        je.remark = f"Auto-created from Debit Note Log {self.name} for Purchase Invoice {self.purchase_invoice}"
+
+        # Debit Supplier
+        je.append("accounts", {
+            "account": supplier_account,
+            "party_type": "Supplier",
+            "party": self.supplier,
+            "debit_in_account_currency": self.discounted_amount,
+            "reference_type": "Purchase Invoice",
+            "reference_name": self.purchase_invoice
+        })
+
+        # Credit Adjusted Account
+        je.append("accounts", {
+            "account": adjusted_account,
+            "credit_in_account_currency": self.discounted_amount
+        })
+
+        je.insert(ignore_permissions=True)
+        je.submit()
+
+        if frappe.get_meta(self.doctype).has_field("jv_reference"):
+            self.db_set("jv_reference", je.name)
+
+        frappe.msgprint(f"Journal Entry <a href='/app/journal-entry/{je.name}'>{je.name}</a> created.")

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -145,7 +145,8 @@ doc_events = {
         "before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"
     },
     "Purchase Invoice": {
-        "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount"
+        "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount",
+        "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
     }
 }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -94,15 +94,16 @@ def get_purchase_invoice_custom_fields():
                 "fieldname": "purchase_schema",
                 "fieldtype": "Select",
                 "label": "Purchase Schema",
-                "options": "Item-Wise\nInvoice-level",
+                "options": "Item-wise\nInvoice-level",
                 "insert_after": "supplier"
 			},
             {
                 "fieldname": "schema_discount_amount",
                 "fieldtype": "Currency",
                 "label": "Schema Discount Amount",
-                "insert_after": "items"
-			},
+                "insert_after": "items",
+                "read_only_depends_on": "eval:doc.purchase_schema == 'Item-wise'"
+			}
         ]
     }
 
@@ -111,12 +112,12 @@ def get_purchase_invoice_item_custom_fields():
     Custom fields that need to be added to the Purchase Invoice Item DocType
     """
     return {
-        "Purchase Invoice Item": [   
+        "Purchase Invoice Item": [
             {
                 "fieldname": "schema_discount_amount",
                 "fieldtype": "Currency",
                 "label": "Schema Discount Amount",
-                "insert_after": "amount"  
+                "insert_after": "amount"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
- Create Journal entry from Debit Note Log.
- Create Debit Note Log from purchase invoice.
- Set read only to Schema discount amount based on purchase schema.

## Solution description
- Create(in Draft mode) debit note log automatically on the submission of purchase invoice.
- Map fields into debit note log from purchase invoice.
- create Journal Entry on the submission of Debit Note Log.
- Set read only to Schema discount amount based on purchase schema.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/a9f5cdaa-42d0-4e42-bee1-99d0d06f6a77)
![image](https://github.com/user-attachments/assets/2b58e9d9-e342-4b45-8146-62f92b7c86c0)

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
