### PR TITLE
feat: Fetch purchase category into serial and bundle from Stock Reconciliation

### DIFF
--- a/e_mart/e_mart/custom_scripts/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/e_mart/e_mart/custom_scripts/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -5,7 +5,7 @@ def set_purchase_category_from_voucher(doc, method):
     Fetches and sets the purchase category from either Purchase Receipt or Purchase Invoice
     to each entry row.
     '''
-    if doc.voucher_type not in ["Purchase Receipt", "Purchase Invoice"] or not doc.voucher_no:
+    if doc.voucher_type not in ["Purchase Receipt", "Purchase Invoice", "Stock Reconciliation"] or not doc.voucher_no:
         return
 
     try:

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -13,6 +13,7 @@ def after_install():
     create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_purchase_invoice_item_custom_fields(),ignore_validate=True, update=True)
+    create_custom_fields(get_stock_reconciliation_custom_fields(),ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -27,6 +28,7 @@ def before_uninstall():
     delete_custom_fields(get_sales_invoice_item_custom_fields())
     delete_custom_fields(get_serial_and_batch_entry_custom_fields())
     delete_custom_fields(get_purchase_invoice_item_custom_fields())
+    delete_custom_fields(get_stock_reconciliation_custom_fields())
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -165,6 +167,22 @@ def get_serial_and_batch_entry_custom_fields():
                 "options": "Normal\nSpecial",
                 "insert_after": "batch_no",
                 "allow_on_submit": 1
+            }
+        ]
+    }
+
+def get_stock_reconciliation_custom_fields():
+    """
+    Custom fields that need to be added to the Stock Reconciliation DocType
+    """
+    return {
+        "Stock Reconciliation": [
+            {
+                "fieldname": "purchase_category",
+                "fieldtype": "Select",
+                "label": "Purchase Category",
+                "options": "Normal\nSpecial",
+                "insert_after": "set_posting_time"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
- Map purchase category into Serial and batch from stock reconciliation.

## Solution description
- Added purchase category into stock reconciliation.
- Fetched purchase category into serial and batch from stock reconciliation.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5e5d45e4-8aa0-43e9-9d5e-a400fc14e8c6)
![image](https://github.com/user-attachments/assets/68ae0696-3a54-4dd2-97b8-64b5ca24a1c2)

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
