### PR TITLE
TASK-2025-01500:Customized Sales Invoice Doctype

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -1,39 +1,3 @@
-// frappe.ui.form.on('Sales Invoice', {
-//     onload: function(frm) {
-//         update_total_buyback_amount(frm);
-//     }
-// });
-
-// frappe.ui.form.on('Buyback Item', {
-//     qty: function(frm, cdt, cdn) {
-//         calculate_row_amount(frm, cdt, cdn);
-//     },
-//     rate: function(frm, cdt, cdn) {
-//         calculate_row_amount(frm, cdt, cdn);
-//     },
-//     buyback_items_remove: function(frm) {
-//         update_total_buyback_amount(frm);
-//     },
-//     buyback_items_add: function(frm) {
-//         update_total_buyback_amount(frm);
-//     }
-// });
-
-// function calculate_row_amount(frm, cdt, cdn) {
-//     let row = locals[cdt][cdn];
-//     row.amount = (row.qty || 0) * (row.rate || 0);
-//     frm.fields_dict.buyback_items.grid.refresh(); // visually refresh
-//     update_total_buyback_amount(frm);
-// }
-
-// function update_total_buyback_amount(frm) {
-//     let total = 0;
-//     (frm.doc.buyback_items || []).forEach(row => {
-//         total += row.amount || 0;
-//     });
-//     frm.set_value('buyback_amount', total);
-// }
-
 frappe.ui.form.on('Sales Invoice', {
     onload(frm) {
         update_total_buyback_amount(frm);

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -1,13 +1,17 @@
 frappe.ui.form.on('Sales Invoice', {
+    // Triggered when the form is loaded
     onload(frm) {
         update_total_buyback_amount(frm);
         set_customer_filter(frm);
     },
 
+    // Triggered when the sales_type field is changed
     sales_type(frm) {
         set_customer_filter(frm);
     },
 
+    // Triggered before saving or submitting the form
+    // If is_buyback is checked, subtract buyback_amount from outstanding_amount
     validate(frm) {
         if (frm.doc.is_buyback && frm.doc.buyback_amount) {
             let new_outstanding = (frm.doc.outstanding_amount || 0) - frm.doc.buyback_amount;
@@ -17,20 +21,29 @@ frappe.ui.form.on('Sales Invoice', {
 });
 
 frappe.ui.form.on('Buyback Item', {
+    // Recalculate amount when quantity is changed
     qty(frm, cdt, cdn) {
         calculate_row_amount(frm, cdt, cdn);
     },
+
+    // Recalculate amount when rate is changed
     rate(frm, cdt, cdn) {
         calculate_row_amount(frm, cdt, cdn);
     },
+
+    // Update total buyback amount when a new row is added
     buyback_items_add(frm) {
         update_total_buyback_amount(frm);
     },
+
+    // Update total buyback amount when a row is removed
     buyback_items_remove(frm) {
         update_total_buyback_amount(frm);
     }
 });
 
+// Calculate the amount for the Buyback Item row
+// and update the total buyback amount
 function calculate_row_amount(frm, cdt, cdn) {
     let row = locals[cdt][cdn];
     row.amount = (row.qty || 0) * (row.rate || 0);
@@ -38,6 +51,8 @@ function calculate_row_amount(frm, cdt, cdn) {
     update_total_buyback_amount(frm);
 }
 
+// Sum all row amounts from buyback_items
+// and set the parent field buyback_amount
 function update_total_buyback_amount(frm) {
     let total = 0;
     (frm.doc.buyback_items || []).forEach(row => {
@@ -46,6 +61,8 @@ function update_total_buyback_amount(frm) {
     frm.set_value('buyback_amount', total);
 }
 
+// Filter customer field to show only providers when sales_type is EMI
+// If selected customer is not a provider, clear it
 function set_customer_filter(frm) {
     frm.set_query("customer", () => {
         if (frm.doc.sales_type === "EMI") {

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -1,6 +1,11 @@
 frappe.ui.form.on('Sales Invoice', {
     onload(frm) {
         update_total_buyback_amount(frm);
+        set_customer_filter(frm);
+    },
+
+    sales_type(frm) {
+        set_customer_filter(frm);
     },
 
     validate(frm) {
@@ -39,4 +44,26 @@ function update_total_buyback_amount(frm) {
         total += row.amount || 0;
     });
     frm.set_value('buyback_amount', total);
+}
+
+function set_customer_filter(frm) {
+    frm.set_query("customer", () => {
+        if (frm.doc.sales_type === "EMI") {
+            return {
+                filters: {
+                    is_provider: 1
+                }
+            };
+        } else {
+            return {};
+        }
+    });
+
+    if (frm.doc.sales_type === "EMI" && frm.doc.customer) {
+        frappe.db.get_value("Customer", frm.doc.customer, "is_provider", (r) => {
+            if (r && r.is_provider !== 1) {
+                frm.set_value("customer", null);
+            }
+        });
+    }
 }

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -1,0 +1,78 @@
+// frappe.ui.form.on('Sales Invoice', {
+//     onload: function(frm) {
+//         update_total_buyback_amount(frm);
+//     }
+// });
+
+// frappe.ui.form.on('Buyback Item', {
+//     qty: function(frm, cdt, cdn) {
+//         calculate_row_amount(frm, cdt, cdn);
+//     },
+//     rate: function(frm, cdt, cdn) {
+//         calculate_row_amount(frm, cdt, cdn);
+//     },
+//     buyback_items_remove: function(frm) {
+//         update_total_buyback_amount(frm);
+//     },
+//     buyback_items_add: function(frm) {
+//         update_total_buyback_amount(frm);
+//     }
+// });
+
+// function calculate_row_amount(frm, cdt, cdn) {
+//     let row = locals[cdt][cdn];
+//     row.amount = (row.qty || 0) * (row.rate || 0);
+//     frm.fields_dict.buyback_items.grid.refresh(); // visually refresh
+//     update_total_buyback_amount(frm);
+// }
+
+// function update_total_buyback_amount(frm) {
+//     let total = 0;
+//     (frm.doc.buyback_items || []).forEach(row => {
+//         total += row.amount || 0;
+//     });
+//     frm.set_value('buyback_amount', total);
+// }
+
+frappe.ui.form.on('Sales Invoice', {
+    onload(frm) {
+        update_total_buyback_amount(frm);
+    },
+
+    validate(frm) {
+        if (frm.doc.is_buyback && frm.doc.buyback_amount) {
+            let new_outstanding = (frm.doc.outstanding_amount || 0) - frm.doc.buyback_amount;
+            frm.set_value('outstanding_amount', Math.max(new_outstanding, 0));
+        }
+    }
+});
+
+frappe.ui.form.on('Buyback Item', {
+    qty(frm, cdt, cdn) {
+        calculate_row_amount(frm, cdt, cdn);
+    },
+    rate(frm, cdt, cdn) {
+        calculate_row_amount(frm, cdt, cdn);
+    },
+    buyback_items_add(frm) {
+        update_total_buyback_amount(frm);
+    },
+    buyback_items_remove(frm) {
+        update_total_buyback_amount(frm);
+    }
+});
+
+function calculate_row_amount(frm, cdt, cdn) {
+    let row = locals[cdt][cdn];
+    row.amount = (row.qty || 0) * (row.rate || 0);
+    frm.fields_dict.buyback_items.grid.refresh();
+    update_total_buyback_amount(frm);
+}
+
+function update_total_buyback_amount(frm) {
+    let total = 0;
+    (frm.doc.buyback_items || []).forEach(row => {
+        total += row.amount || 0;
+    });
+    frm.set_value('buyback_amount', total);
+}

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import flt
 
 def validate_buyback_fields(doc, method=None):
     """Calculate row amount, total buyback amount, and adjust outstanding amount if is_buyback is checked."""
@@ -17,3 +18,32 @@ def validate_buyback_fields(doc, method=None):
     # 3. Subtract buyback from outstanding amount
     if doc.is_buyback and doc.buyback_amount:
         doc.outstanding_amount = max((doc.outstanding_amount or 0) - doc.buyback_amount, 0)
+
+def create_scrap_stock_entry(doc, method):
+    if not doc.buyback_items:
+        return
+
+    scrap_warehouse = frappe.db.get_single_value("E-mart Settings", "scrap_warehouse")
+    if not scrap_warehouse:
+        frappe.throw("Please set the Scrap Warehouse in E-mart Settings.")
+
+    stock_entry = frappe.new_doc("Stock Entry")
+    stock_entry.purpose = "Material Receipt"
+    stock_entry.stock_entry_type = "Material Receipt"
+    stock_entry.company = doc.company
+    stock_entry.to_warehouse = scrap_warehouse
+    stock_entry.sales_invoice_no = doc.name  # Optional
+
+    for row in doc.buyback_items:
+        if row.item and flt(row.qty) > 0:
+            stock_entry.append("items", {
+                "item_code": row.item,
+                "qty": row.qty,
+                "uom": "Nos",  # adjust as needed
+                "t_warehouse": scrap_warehouse,
+                "basic_rate": row.rate
+            })
+
+    stock_entry.insert()
+    stock_entry.submit()
+    frappe.msgprint(f' Scrap Stock Entry Created: <a href="{frappe.utils.get_url_to_form(stock_entry.doctype, stock_entry.name)}" target="_blank"><b>{stock_entry.name}</b></a>',alert=True,indicator='green')

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -2,48 +2,61 @@ import frappe
 from frappe.utils import flt
 
 def validate_buyback_fields(doc, method=None):
-    """Calculate row amount, total buyback amount, and adjust outstanding amount if is_buyback is checked."""
+	
+	"""
+	Triggered on validation of Sales Invoice.
 
-    total = 0
+	1. Calculates amount for each Buyback Item row.
+	2. Sums up all row amounts into buyback_amount.
+	3. Adjusts the outstanding_amount if is_buyback is checked.
+	"""
 
-    # 1. Calculate amount per row
-    if doc.buyback_items:
-        for row in doc.buyback_items:
-            row.amount = (row.qty or 0) * (row.rate or 0)
-            total += row.amount
+	total = 0
 
-    # 2. Set total buyback amount
-    doc.buyback_amount = total
+	# 1. Calculate amount per row
+	if doc.buyback_items:
+		for row in doc.buyback_items:
+			row.amount = (row.qty or 0) * (row.rate or 0)
+			total += row.amount
 
-    # 3. Subtract buyback from outstanding amount
-    if doc.is_buyback and doc.buyback_amount:
-        doc.outstanding_amount = max((doc.outstanding_amount or 0) - doc.buyback_amount, 0)
+	# 2. Set total buyback amount
+	doc.buyback_amount = total
+
+	# 3. Subtract buyback from outstanding amount
+	if doc.is_buyback and doc.buyback_amount:
+		doc.outstanding_amount = max((doc.outstanding_amount or 0) - doc.buyback_amount, 0)
 
 def create_scrap_stock_entry(doc, method):
-    if not doc.buyback_items:
-        return
+	"""
+	On submission of Sales Invoice:
+	Creates a Stock Entry to move Buyback Items to Scrap Warehouse
+	(Scrap warehouse is fetched from E-mart Settings).
+	"""
 
-    scrap_warehouse = frappe.db.get_single_value("E-mart Settings", "scrap_warehouse")
-    if not scrap_warehouse:
-        frappe.throw("Please set the Scrap Warehouse in E-mart Settings.")
+	if not doc.buyback_items:
+		return
 
-    stock_entry = frappe.new_doc("Stock Entry")
-    stock_entry.purpose = "Material Receipt"
-    stock_entry.stock_entry_type = "Material Receipt"
-    stock_entry.company = doc.company
-    stock_entry.to_warehouse = scrap_warehouse
-    stock_entry.sales_invoice_no = doc.name  # Optional
+	scrap_warehouse = frappe.db.get_single_value("E-mart Settings", "scrap_warehouse")
+	if not scrap_warehouse:
+		frappe.throw("Please set the Scrap Warehouse in E-mart Settings.")
 
-    for row in doc.buyback_items:
-        if row.item and flt(row.qty) > 0:
-            stock_entry.append("items", {
-                "item_code": row.item,
-                "qty": row.qty,
-                "uom": "Nos",  # adjust as needed
-                "t_warehouse": scrap_warehouse,
-                "basic_rate": row.rate
-            })
+	stock_entry = frappe.new_doc("Stock Entry")
+	stock_entry.purpose = "Material Receipt"
+	stock_entry.stock_entry_type = "Material Receipt"
+	stock_entry.company = doc.company
+	stock_entry.to_warehouse = scrap_warehouse
+	stock_entry.sales_invoice_no = doc.name  # Optional
 
-    stock_entry.insert()
-    stock_entry.submit()
-    frappe.msgprint(f' Scrap Stock Entry Created: <a href="{frappe.utils.get_url_to_form(stock_entry.doctype, stock_entry.name)}" target="_blank"><b>{stock_entry.name}</b></a>',alert=True,indicator='green')
+	for row in doc.buyback_items:
+		if row.item and flt(row.qty) > 0:
+			stock_entry.append("items", {
+				"item_code": row.item,
+				"qty": row.qty,
+				"uom": "Nos",  # adjust as needed
+				"t_warehouse": scrap_warehouse,
+				"basic_rate": row.rate
+			})
+
+	stock_entry.insert()
+	stock_entry.submit()
+	frappe.msgprint(f' Scrap Stock Entry Created: <a href="{frappe.utils.get_url_to_form(stock_entry.doctype, stock_entry.name)}" target="_blank"><b>{stock_entry.name}</b></a>',alert=True,indicator='green')

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,0 +1,35 @@
+# import frappe
+
+# def calculate_total_buyback_amount(doc, method=None):
+#     total = 0
+#     if doc.buyback_items:
+#         for row in doc.buyback_items:
+#             row.amount = (row.qty or 0) * (row.rate or 0)
+#             total += row.amount
+#     doc.buyback_amount = total
+
+# def adjust_outstanding_amount(doc, method=None):
+#     calculate_total_buyback_amount(doc)  # Ensure buyback_amount is updated
+
+#     if doc.buy_back and doc.buyback_amount:
+#         doc.outstanding_amount = (doc.outstanding_amount or 0) - doc.buyback_amount
+
+import frappe
+
+def validate_buyback_fields(doc, method=None):
+    """Calculate row amount, total buyback amount, and adjust outstanding amount if is_buyback is checked."""
+
+    total = 0
+
+    # 1. Calculate amount per row
+    if doc.buyback_items:
+        for row in doc.buyback_items:
+            row.amount = (row.qty or 0) * (row.rate or 0)
+            total += row.amount
+
+    # 2. Set total buyback amount
+    doc.buyback_amount = total
+
+    # 3. Subtract buyback from outstanding amount
+    if doc.is_buyback and doc.buyback_amount:
+        doc.outstanding_amount = max((doc.outstanding_amount or 0) - doc.buyback_amount, 0)

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,19 +1,3 @@
-# import frappe
-
-# def calculate_total_buyback_amount(doc, method=None):
-#     total = 0
-#     if doc.buyback_items:
-#         for row in doc.buyback_items:
-#             row.amount = (row.qty or 0) * (row.rate or 0)
-#             total += row.amount
-#     doc.buyback_amount = total
-
-# def adjust_outstanding_amount(doc, method=None):
-#     calculate_total_buyback_amount(doc)  # Ensure buyback_amount is updated
-
-#     if doc.buy_back and doc.buyback_amount:
-#         doc.outstanding_amount = (doc.outstanding_amount or 0) - doc.buyback_amount
-
 import frappe
 
 def validate_buyback_fields(doc, method=None):

--- a/e_mart/e_mart/doctype/buyback_item/buyback_item.json
+++ b/e_mart/e_mart/doctype/buyback_item/buyback_item.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "format:BUYBACK-{YYYY}-{#####}",
+ "creation": "2025-06-30 12:43:48.987855",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_uqfy",
+  "item",
+  "rate",
+  "qty",
+  "amount"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_uqfy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Rate"
+  },
+  {
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Qty"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-06-30 16:30:15.114718",
+ "modified_by": "Administrator",
+ "module": "E Mart",
+ "name": "Buyback Item",
+ "naming_rule": "Expression",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/e_mart/e_mart/doctype/buyback_item/buyback_item.py
+++ b/e_mart/e_mart/doctype/buyback_item/buyback_item.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class BuybackItem(Document):
+	pass

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -26,7 +26,7 @@ app_license = "mit"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/e_mart/css/e_mart.css"
-# app_include_js = "/assets/e_mart/js/e_mart.js"
+app_include_js = "/assets/e_mart/js/sales_invoice.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/e_mart/css/e_mart.css"
@@ -43,7 +43,10 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {"Purchase Invoice" : "e_mart/custom_scripts/purchase_invoice/purchase_invoice.js"}
+doctype_js = {
+	"Purchase Invoice" : "e_mart/custom_scripts/purchase_invoice/purchase_invoice.js",
+	"Sales Invoice" : "e_mart/custom_scripts/sales_invoice/sales_invoice.js"
+}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -147,6 +150,9 @@ doc_events = {
     "Purchase Invoice": {
         "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount",
         "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
+    },
+	"Sales Invoice": {
+         "validate": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields"
     }
 }
 

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -152,7 +152,8 @@ doc_events = {
         "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
     },
 	"Sales Invoice": {
-         "validate": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields"
+         "validate": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
+         "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry"
     }
 }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -16,6 +16,7 @@ def after_install():
     create_custom_fields(get_item_custom_fields(),ignore_validate=True, update=True)
     create_custom_fields(get_customer_custom_fields(),ignore_validate=True, update=True)
     create_custom_fields(get_stock_reconciliation_custom_fields(),ignore_validate=True, update=True)
+    create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -33,6 +34,8 @@ def before_uninstall():
     delete_custom_fields(get_item_custom_fields())
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_stock_reconciliation_custom_fields())
+    delete_custom_fields(get_sales_invoice_custom_fields())
+    
 
 
 def delete_custom_fields(custom_fields: dict):
@@ -286,3 +289,66 @@ def get_property_setters():
             "value": 1
         }
     ]
+def get_sales_invoice_custom_fields():
+    return {
+        "Sales Invoice": [
+            {
+                "fieldname": "sales_type",
+                "fieldtype": "Select",
+                "label": "Sales Type",
+                "options": "\nCash\nCredit\nEMI",
+                "insert_after": "is_debit_note"
+            },
+            {
+                "fieldname": "actual_customer",
+                "fieldtype": "Link",
+                "label": "Actual Customer",
+                "options": "Customer",
+                "depends_on": "eval:doc.sales_type == 'EMI' && doc.customer",
+                "insert_after": "customer"
+            },
+            {
+                "fieldname": "is_buyback",
+                "fieldtype": "Check",
+                "label": "Is Buyback",
+                "insert_after": "actual_customer"
+            },
+            {
+                "fieldname": "buyback_section",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after": "sales_type"
+            },
+            {
+                "fieldname": "buyback_items",
+                "fieldtype": "Table",
+                "label": "Buyback Items",
+                "options": "Buyback Item",
+                "insert_after": "buyback_section",
+                "depends_on": "eval:doc.is_buyback"
+            },
+            {
+                "fieldname": "buyback_amount_section",
+                "fieldtype": "Section Break",
+                "label": "",
+                "insert_after": "buyback_items",
+                "depends_on": "eval:doc.is_buyback"
+            },
+            {
+                "fieldname": "buyback_column_break",
+                "fieldtype": "Column Break",
+                "insert_after": "buyback_amount_section"
+            },
+            {
+                "fieldname": "buyback_items_column_break",
+                "fieldtype": "Column Break",
+                "insert_after": "buyback_column_break"
+            },
+            {
+                "fieldname": "buyback_amount",
+                "fieldtype": "Currency",
+                "label": "Buyback Amount",
+                "insert_after": "buyback_items_column_break"
+            }
+        ]
+    }


### PR DESCRIPTION
## Feature description
Need to: 

Add the following fields into Sales Invoice doctype

      - Sales Type(Select->CASH/Credit/EMI)
      - Actual Customer(Customer)(depends on sales type: EMI)
      - Is Buyback(checkbox)
      - Buyback Amount 
 - Create child table Buyback Items(fields-> Item,rate,qty,amount)
- Calculate Buyback Amount based on buyback items
- Calculate total outstanding amount if is_buyback checkbox is checked
- Add is_provider filter for Customer when Sales Type is EMI
- create stock entry on Submission of Sales Invoice to scrap warehouse

## Solution description

Added the following fields into Sales Invoice.

      -   Sales Type(Select->CASH/Credit/EMI)
      -   Actual Customer(Customer)(depends on sales type: EMI)
      -   Is Buyback(checkbox)
      -   Buyback Amount field is visible when   Is Buyback checkbox is checked
-   Created child table Buyback Items(fields->Item,rate,qty,amount)
- Calculated Buyback Amount based on buyback items
- Calculated total outstanding amount if is_buyback checkbox is checked that is Subtraction of  buyback from 
outstanding amount
- Added is_provider filter for Customer when Sales Type is EMI using set query function
- Created Stock Entry to Scrap Warehouse on Sales Invoice submission if buyback items exist

## Output
[Screencast from 01-07-25 12:04:37 PM IST.webm](https://github.com/user-attachments/assets/2ec24901-51a2-44ec-8e38-60b309555d47)

[Screencast from 01-07-25 12:49:25 PM IST.webm](https://github.com/user-attachments/assets/87078709-907e-4586-881d-3f55639875e1)


[Screencast from 01-07-25 01:14:20 PM IST.webm](https://github.com/user-attachments/assets/f35910a8-adee-4ebb-9943-06ee478fd677)


## Areas affected and ensured
- Sales Invoice doctype

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Chrome