### PR TITLE
TASK-2025-01518:Customized Sales Order Item and Sales Invoice Item

### DIFF
--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -203,6 +203,12 @@ def get_sales_order_item_custom_fields():
                 "fieldtype": "Check",
                 "label": "Allow Commission",
                 "insert_after": "item_tax_template"
+            },
+            {
+                "fieldname": "profit_for_commission",
+                "fieldtype": "Currency",
+                "label": "Profit for Commission",
+                "insert_after": "allow_commission"
             }
         ]
     }
@@ -218,6 +224,12 @@ def get_sales_invoice_item_custom_fields():
                 "fieldtype": "Check",
                 "label": "Allow Commission",
                 "insert_after": "item_tax_template"
+            },
+            {
+                "fieldname": "profit_for_commission",
+                "fieldtype": "Currency",
+                "label": "Profit for Commission",
+                "insert_after": "allow_commission"
             }
         ]
     }


### PR DESCRIPTION
## Feature description
Need to: 

Add the following fields into sales order item and sales invoice item.
- Profit for commission(Currency)

## Solution description
Added  Profit for commission field into sales order item and sales invoice item through setup file


## Output
![image](https://github.com/user-attachments/assets/4b4bef6a-3fc5-4bff-b4d2-51bd83832071)

![image](https://github.com/user-attachments/assets/52374f7b-b59a-4259-a26c-974e012e51a8)



## Areas affected and ensured
- Sales Invoice doctype and Sales Order doctype 

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Chrome