### PR TITLE
feat:Calculted EMI amount based on number of installment

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -134,25 +134,25 @@ function generate_emi_schedule(frm) {
         return;
     }
 
-    frappe.db.get_doc('Customer', customer)
-        .then(doc => {
-            let emi_start_date = doc.emi_start_date;
-            if (!emi_start_date) {
-                return; 
-            }
+    frappe.db.get_value('Customer', customer, 'emi_start_date')
+    .then(r => {
+        let emi_start_date = r.message.emi_start_date;
+        if (!emi_start_date) {
+            return;
+        }
 
-            frm.clear_table('emi_duration');
+        frm.clear_table('emi_duration');
 
-            let installment_amount = Number(emi_amount) / Number(no_of_installments);
+        let installment_amount = Number(emi_amount) / Number(no_of_installments);
 
-            for (let i = 0; i < Number(no_of_installments); i++) {
-                let installment_date = frappe.datetime.add_months(emi_start_date, i);
-                frm.add_child('emi_duration', {
-                    date: installment_date,
-                    amount: installment_amount
-                });
-            }
+        for (let i = 0; i < Number(no_of_installments); i++) {
+            let installment_date = frappe.datetime.add_months(emi_start_date, i);
+            frm.add_child('emi_duration', {
+                date: installment_date,
+                amount: installment_amount
+            });
+        }
 
-            frm.refresh_field('emi_duration');
-        });
+        frm.refresh_field('emi_duration');
+    });
 }

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
 frappe.ui.form.on('Sales Invoice', {
     // Triggered when the form is loaded
     onload(frm) {
@@ -9,6 +12,24 @@ frappe.ui.form.on('Sales Invoice', {
     sales_type(frm) {
         set_customer_filter(frm);
     },
+    // Triggered when relevant fields change for EMI recalculation
+    down_payment_amount: function(frm) {
+        update_emi_amount(frm);
+        generate_emi_schedule(frm); 
+    },
+    total: function(frm) {
+        update_emi_amount(frm);
+        generate_emi_schedule(frm);
+    },
+    no_of_installment: function(frm) {
+        generate_emi_schedule(frm);
+    },
+    emi_amount: function(frm) {
+        generate_emi_schedule(frm);
+    },
+    customer: function(frm) {
+        generate_emi_schedule(frm);
+    },
 
     // Triggered before saving or submitting the form
     // If is_buyback is checked, subtract buyback_amount from outstanding_amount
@@ -17,6 +38,8 @@ frappe.ui.form.on('Sales Invoice', {
             let new_outstanding = (frm.doc.outstanding_amount || 0) - frm.doc.buyback_amount;
             frm.set_value('outstanding_amount', Math.max(new_outstanding, 0));
         }
+        update_emi_amount(frm);
+        generate_emi_schedule(frm);
     }
 });
 
@@ -83,4 +106,53 @@ function set_customer_filter(frm) {
             }
         });
     }
+}
+
+
+/**
+ * Calculates the EMI amount after deducting the down payment
+ * and updates the emi_amount field immediately.
+ */
+function update_emi_amount(frm) {
+    let down_payment = frm.doc.down_payment_amount || 0;
+    let total = frm.doc.total || 0;
+    let emi_amount = total - down_payment;
+
+    frm.set_value('emi_amount', emi_amount);
+}
+
+/**
+ * Generates EMI Duration child table rows dynamically
+ * based on customer emi_start_date, emi_amount, and no_of_installment.
+ */
+function generate_emi_schedule(frm) {
+    let customer = frm.doc.customer;
+    let no_of_installments = frm.doc.no_of_installment;
+    let emi_amount = frm.doc.emi_amount;
+
+    if (!customer || !no_of_installments || !emi_amount) {
+        return;
+    }
+
+    frappe.db.get_doc('Customer', customer)
+        .then(doc => {
+            let emi_start_date = doc.emi_start_date;
+            if (!emi_start_date) {
+                return; 
+            }
+
+            frm.clear_table('emi_duration');
+
+            let installment_amount = Number(emi_amount) / Number(no_of_installments);
+
+            for (let i = 0; i < Number(no_of_installments); i++) {
+                let installment_date = frappe.datetime.add_months(emi_start_date, i);
+                frm.add_child('emi_duration', {
+                    date: installment_date,
+                    amount: installment_amount
+                });
+            }
+
+            frm.refresh_field('emi_duration');
+        });
 }

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import flt
+from frappe.utils import flt,add_months
 
 def validate_buyback_fields(doc, method=None):
 	
@@ -60,3 +60,41 @@ def create_scrap_stock_entry(doc, method):
 	stock_entry.insert()
 	stock_entry.submit()
 	frappe.msgprint(f' Scrap Stock Entry Created: <a href="{frappe.utils.get_url_to_form(stock_entry.doctype, stock_entry.name)}" target="_blank"><b>{stock_entry.name}</b></a>',alert=True,indicator='green')
+
+def update_emi_amount(doc, method):
+    """
+	Generate the emi amount after deducting the down payment
+    """
+    down_payment = doc.down_payment_amount or 0
+    total = doc.total or 0
+    doc.emi_amount = total - down_payment
+
+def generate_emi_schedule(doc, method):
+    """
+    Generate EMI Duration table rows based on customer emi_start_date and number of installments
+    """
+
+    if not doc.customer:
+        frappe.throw("Please select a Customer.")
+
+    customer = frappe.get_doc("Customer", doc.customer)
+    emi_start_date = customer.get("emi_start_date")
+    if not emi_start_date:
+        frappe.throw("Customer does not have an EMI Start Date.")
+
+    no_of_installments = doc.get("no_of_installment")
+    if not no_of_installments:
+        frappe.throw("Please set No of Installments")
+
+    emi_amount = doc.get("emi_amount")  
+    doc.set("emi_duration", [])
+
+    installment_amount = flt(emi_amount) / int(no_of_installments)
+
+    for i in range(int(no_of_installments)):
+        installment_date = add_months(emi_start_date, i)
+        doc.append("emi_duration", {
+            "date": installment_date,
+            "amount": installment_amount
+        })
+

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -62,39 +62,41 @@ def create_scrap_stock_entry(doc, method):
 	frappe.msgprint(f' Scrap Stock Entry Created: <a href="{frappe.utils.get_url_to_form(stock_entry.doctype, stock_entry.name)}" target="_blank"><b>{stock_entry.name}</b></a>',alert=True,indicator='green')
 
 def update_emi_amount(doc, method):
-    """
+	"""
 	Generate the emi amount after deducting the down payment
-    """
-    down_payment = doc.down_payment_amount or 0
-    total = doc.total or 0
-    doc.emi_amount = total - down_payment
+	"""
+	down_payment = doc.down_payment_amount or 0
+	total = doc.total or 0
+	doc.emi_amount = total - down_payment
 
 def generate_emi_schedule(doc, method):
-    """
-    Generate EMI Duration table rows based on customer emi_start_date and number of installments
-    """
+	"""
+	Generate EMI Duration table rows based on customer emi_start_date and number of installments
+	"""
+	if doc.sales_type != "EMI":
+		return
 
-    if not doc.customer:
-        frappe.throw("Please select a Customer.")
+	if not doc.customer:
+		frappe.throw("Please select a Customer.")
 
-    customer = frappe.get_doc("Customer", doc.customer)
-    emi_start_date = customer.get("emi_start_date")
-    if not emi_start_date:
-        frappe.throw("Customer does not have an EMI Start Date.")
+	customer = frappe.get_doc("Customer", doc.customer)
+	emi_start_date = customer.get("emi_start_date")
+	if not emi_start_date:
+		frappe.throw("Customer does not have an EMI Start Date.")
 
-    no_of_installments = doc.get("no_of_installment")
-    if not no_of_installments:
-        frappe.throw("Please set No of Installments")
+	no_of_installments = doc.get("no_of_installment")
+	if not no_of_installments:
+		frappe.throw("Please set No of Installments")
 
-    emi_amount = doc.get("emi_amount")  
-    doc.set("emi_duration", [])
+	emi_amount = doc.get("emi_amount")  
+	doc.set("emi_duration", [])
 
-    installment_amount = flt(emi_amount) / int(no_of_installments)
+	installment_amount = flt(emi_amount) / int(no_of_installments)
 
-    for i in range(int(no_of_installments)):
-        installment_date = add_months(emi_start_date, i)
-        doc.append("emi_duration", {
-            "date": installment_date,
-            "amount": installment_amount
-        })
+	for i in range(int(no_of_installments)):
+		installment_date = add_months(emi_start_date, i)
+		doc.append("emi_duration", {
+			"date": installment_date,
+			"amount": installment_amount
+		})
 

--- a/e_mart/e_mart/doctype/emi_duration/emi_duration.json
+++ b/e_mart/e_mart/doctype/emi_duration/emi_duration.json
@@ -1,0 +1,38 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-01 11:17:17.665872",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "date",
+  "amount"
+ ],
+ "fields": [
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "label": "Date"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-07-01 11:18:29.807562",
+ "modified_by": "Administrator",
+ "module": "E Mart",
+ "name": "EMI Duration",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/e_mart/e_mart/doctype/emi_duration/emi_duration.py
+++ b/e_mart/e_mart/doctype/emi_duration/emi_duration.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EMIDuration(Document):
+	pass

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -151,16 +151,16 @@ doc_events = {
         "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount",
         "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
     },
-	"Sales Invoice": {
+    "Sales Invoice": {
          "validate":[
-			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
-			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule"
-			  ],
+              "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
+              "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule"
+               ],
          "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry",
-		 "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+         "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
 
     }
-		
+    
 }
 
 # Scheduled Tasks

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -152,11 +152,16 @@ doc_events = {
         "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
     },
 	"Sales Invoice": {
-         "validate": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
-         "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry"
-    }
-}
+         "validate":[
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule"
+			  ],
+         "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry",
+		 "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
 
+    }
+		
+}
 
 # Scheduled Tasks
 # ---------------

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -205,57 +205,6 @@ def get_sales_order_item_custom_fields():
         ]
     }
 
-def get_sales_invoice_custom_fields():
-    """
-    Custom fields that need to be added to the Sales Invoice DocType
-    """
-    return {
-        "Sales Invoice": [
-            {
-                "fieldname": "emi_details_section",
-                "fieldtype": "Section Break",
-                "label": "EMI Details",
-                "insert_after": "total"
-            },
-            {
-                "fieldname": "down_payment_amount",
-                "fieldtype": "Currency",
-                "label": "Down Payment Amount",
-                "insert_after": "emi_details_section"
-            },
-            {
-                "fieldname": "emi_amount",
-                "fieldtype": "Currency",
-                "label": "EMI AMOUNT",
-                "insert_after": "down_payment_amount"
-            },
-            {
-                "fieldname": "installment_column_break",
-                "fieldtype": "Column Break",
-                "insert_after": "emi_amount"
-            },
-            {
-                "fieldname": "no_of_installment",
-                "fieldtype": "Int",
-                "label": "No Of Installment",
-                "insert_after": "installment_column_break"
-            },
-            {
-                "fieldname": "emi_duration_section",
-                "fieldtype": "Section Break",
-                "label": "EMI Duration",
-                "insert_after": "no_of_installment"
-            },
-            {
-                "fieldname": "emi_duration",
-                "fieldtype": "Table",
-                "label": "EMI Duration",
-                "options":"EMI Duration",
-                "insert_after": "emi_duration_section"
-            }           
-        ]
-    }
-
 def get_sales_invoice_item_custom_fields():
     """
     Custom fields that need to be added to the Sales Invoice Item DocType
@@ -398,6 +347,52 @@ def get_sales_invoice_custom_fields():
                 "fieldtype": "Currency",
                 "label": "Buyback Amount",
                 "insert_after": "buyback_items_column_break"
-            }
+            },
+             {
+                "fieldname": "emi_details_section",
+                "fieldtype": "Section Break",
+                "label": "EMI Details",
+                "insert_after": "total",
+                "depends_on": "eval:doc.sales_type == 'EMI'"
+
+            },
+            {
+                "fieldname": "down_payment_amount",
+                "fieldtype": "Currency",
+                "label": "Down Payment Amount",
+                "insert_after": "emi_details_section"
+            },
+            {
+                "fieldname": "emi_amount",
+                "fieldtype": "Currency",
+                "label": "EMI AMOUNT",
+                "insert_after": "down_payment_amount"
+            },
+            {
+                "fieldname": "installment_column_break",
+                "fieldtype": "Column Break",
+                "insert_after": "emi_amount"
+            },
+            {
+                "fieldname": "no_of_installment",
+                "fieldtype": "Int",
+                "label": "No Of Installment",
+                "insert_after": "installment_column_break"
+            },
+            {
+                "fieldname": "emi_duration_section",
+                "fieldtype": "Section Break",
+                "label": "EMI Duration",
+                "insert_after": "no_of_installment",
+                "depends_on": "eval:doc.sales_type == 'EMI'"
+
+            },
+            {
+                "fieldname": "emi_duration",
+                "fieldtype": "Table",
+                "label": "EMI Duration",
+                "options":"EMI Duration",
+                "insert_after": "emi_duration_section"
+            }  
         ]
     }

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -35,8 +35,6 @@ def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_stock_reconciliation_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
-    
-
 
 def delete_custom_fields(custom_fields: dict):
     """
@@ -112,7 +110,7 @@ def get_purchase_invoice_custom_fields():
                 "label": "Schema Discount Amount",
                 "insert_after": "items",
                 "read_only_depends_on": "eval:doc.purchase_schema == 'Item-wise'"
-			}
+            }
         ]
     }
 
@@ -204,6 +202,57 @@ def get_sales_order_item_custom_fields():
                 "label": "Allow Commission",
                 "insert_after": "item_tax_template"
             }
+        ]
+    }
+
+def get_sales_invoice_custom_fields():
+    """
+    Custom fields that need to be added to the Sales Invoice DocType
+    """
+    return {
+        "Sales Invoice": [
+            {
+                "fieldname": "emi_details_section",
+                "fieldtype": "Section Break",
+                "label": "EMI Details",
+                "insert_after": "total"
+            },
+            {
+                "fieldname": "down_payment_amount",
+                "fieldtype": "Currency",
+                "label": "Down Payment Amount",
+                "insert_after": "emi_details_section"
+            },
+            {
+                "fieldname": "emi_amount",
+                "fieldtype": "Currency",
+                "label": "EMI AMOUNT",
+                "insert_after": "down_payment_amount"
+            },
+            {
+                "fieldname": "installment_column_break",
+                "fieldtype": "Column Break",
+                "insert_after": "emi_amount"
+            },
+            {
+                "fieldname": "no_of_installment",
+                "fieldtype": "Int",
+                "label": "No Of Installment",
+                "insert_after": "installment_column_break"
+            },
+            {
+                "fieldname": "emi_duration_section",
+                "fieldtype": "Section Break",
+                "label": "EMI Duration",
+                "insert_after": "no_of_installment"
+            },
+            {
+                "fieldname": "emi_duration",
+                "fieldtype": "Table",
+                "label": "EMI Duration",
+                "options":"EMI Duration",
+                "insert_after": "emi_duration_section"
+            }           
         ]
     }
 


### PR DESCRIPTION
Feature description
Added the fields in sales invoice (EMI down payment,EMI amount,No of instalment).
Added child table in sales invoice called EMI Duration

Solution description

Fetched EMI start date from customer doctype to sales invoice.
EMI amount calculated by deducting down payment from total.
Map finance invoice details into finance invoice from sales invoice.
EMI amount split equal to every month on the basis of number of instalment

Output screenshots (optional)

![Screenshot from 2025-07-01 17-34-53](https://github.com/user-attachments/assets/fac69a64-014b-445c-8a18-9526e33b0bc2)

Is there any existing behaviour change of other features due to this code change?
No

Was this feature tested on the browsers?
Chrome