### PR TITLE
TASK-2025-01552:Added Debit Note Log connection from Purchase invoice

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice_dashboard/purchase_invoice_dashboard.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice_dashboard/purchase_invoice_dashboard.py
@@ -1,0 +1,14 @@
+from frappe import _
+
+def get_data(data=None):
+    return {
+        "fieldname": "purchase_invoice",  
+        "non_standard_fieldnames": {
+            "Debit Note Log": "purchase_invoice"
+        },
+        "transactions": [
+            {
+                "items": ["Debit Note Log"]
+            }
+        ]
+    }

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -199,9 +199,9 @@ doc_events = {
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
-# override_doctype_dashboards = {
-# 	"Task": "e_mart.task.get_dashboard_data"
-# }
+override_doctype_dashboards = {
+	'Purchase Invoice': 'e_mart.e_mart.custom_scripts.purchase_invoice_dashboard.purchase_invoice_dashboard.get_data'
+}
 
 # exempt linked doctypes from being automatically cancelled
 #


### PR DESCRIPTION
## Feature description
Need to: Add Debit Note Log connection from Purchase invoice doctype

## Solution description
Added Debit Note Log connection from Purchase invoice

## Output
[Screencast from 03-07-25 02:38:21 PM IST.webm](https://github.com/user-attachments/assets/afdf0546-621f-48bc-a02a-1eb647979268)


## Areas affected and ensured
-Purchase Invoice doctype 

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Chrome