### PR TITLE
fix:updated outstanding amount on change in child tables in Sales Invoice doctype

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -92,39 +92,38 @@ frappe.ui.form.on('Buyback Item', {
 });
 // Sales Invoice Items child table
 frappe.ui.form.on('Sales Invoice Item', {
-    qty(frm) {
-        frm.trigger("calculate_totals");
-    },
-    rate(frm) {
-        frm.trigger("calculate_totals");
-    },
-    amount(frm) {
-        frm.trigger("calculate_totals");
-    },
-    items_add(frm) {
-        frm.trigger("calculate_totals");
-    },
-    items_remove(frm) {
-        frm.trigger("calculate_totals");
-    }
+	qty(frm) {
+		frm.trigger("calculate_totals");
+	},
+	rate(frm) {
+		frm.trigger("calculate_totals");
+	},
+	amount(frm) {
+		frm.trigger("calculate_totals");
+	},
+	items_add(frm) {
+		frm.trigger("calculate_totals");
+	},
+	items_remove(frm) {
+		frm.trigger("calculate_totals");
+	}
 });
 
 // Taxes child table
 frappe.ui.form.on('Sales Taxes and Charges', {
-    tax_amount(frm) {
-        frm.trigger("calculate_totals");
-    },
-    rate(frm) {
-        frm.trigger("calculate_totals");
-    },
-    taxes_add(frm) {
-        frm.trigger("calculate_totals");
-    },
-    taxes_remove(frm) {
-        frm.trigger("calculate_totals");
-    }
+	tax_amount(frm) {
+		frm.trigger("calculate_totals");
+	},
+	rate(frm) {
+		frm.trigger("calculate_totals");
+	},
+	taxes_add(frm) {
+		frm.trigger("calculate_totals");
+	},
+	taxes_remove(frm) {
+		frm.trigger("calculate_totals");
+	}
 });
-
 
 // Calculate Buyback Row Amount
 function calculate_row_amount(frm, cdt, cdn) {
@@ -147,17 +146,17 @@ function update_total_buyback_amount(frm) {
 
 // Calculate Outstanding Amount
 function update_outstanding_amount(frm) {
-    if (frm.doc.docstatus === 0) { // only allow before submit
-        const total = flt(frm.doc.total || 0);
-        const taxes = flt(frm.doc.total_taxes_and_charges || 0);
-        const buyback = flt(frm.doc.buyback_amount || 0);
+	if (frm.doc.docstatus === 0) { 
+		const total = flt(frm.doc.total || 0);
+		const taxes = flt(frm.doc.total_taxes_and_charges || 0);
+		const buyback = flt(frm.doc.buyback_amount || 0);
 
-        let outstanding = total + taxes;
-        if (frm.doc.is_buyback) {
-            outstanding -= buyback;
-        }
-        frm.set_value('outstanding_amount', Math.max(outstanding, 0));
-    }
+		let outstanding = total + taxes;
+		if (frm.doc.is_buyback) {
+			outstanding -= buyback;
+		}
+		frm.set_value('outstanding_amount', Math.max(outstanding, 0));
+	}
 }
 
 // Calculate Rounded Total
@@ -172,7 +171,6 @@ function update_rounded_total(frm) {
 	}
 	frm.set_value('rounded_total', Math.round(grand_total));
 }
-
 
 // Filter customer field to show only providers when sales_type is EMI
 // If selected customer is not a provider, clear it

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -3,26 +3,29 @@
 
 frappe.ui.form.on('Sales Invoice', {
 	onload(frm) {
-		update_total_buyback_amount(frm);
+		frm.fields_dict.buyback_items.grid.wrapper.on('change', function () {
+			update_total_buyback_amount(frm);
+		});
 		set_customer_filter(frm);
 	},
 	refresh: function (frm) {
-        if (!frm.is_new() && frm.doc.sales_type === "EMI") {
-            frm.add_custom_button(__('Create Finance Invoice'), function () {
-                frappe.call({
-                    method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_finance_invoice",
-                    args: {
-                        sales_invoice_name: frm.doc.name
-                    },
-                    callback: function (r) {
-                        if (r.message) {
-                            frappe.set_route('Form', 'Finance Invoice', r.message);
-                        }
-                    }
-                });
-            });
-        }
-    },
+		update_outstanding_amount(frm);
+		if (!frm.is_new() && frm.doc.sales_type === "EMI") {
+			frm.add_custom_button(__('Create Finance Invoice'), function () {
+				frappe.call({
+					method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_finance_invoice",
+					args: {
+						sales_invoice_name: frm.doc.name
+					},
+					callback: function (r) {
+						if (r.message) {
+							frappe.set_route('Form', 'Finance Invoice', r.message);
+						}
+					}
+				});
+			});
+		}
+	},
 	sales_type(frm) {
 		set_customer_filter(frm);
 	},
@@ -32,8 +35,20 @@ frappe.ui.form.on('Sales Invoice', {
 		generate_emi_schedule(frm); 
 	},
 	total: function(frm) {
+		update_outstanding_amount(frm);
 		update_emi_amount(frm);
 		generate_emi_schedule(frm);
+	},
+	total_taxes_and_charges(frm) {
+		update_outstanding_amount(frm);
+	},
+
+	buyback_amount(frm) {
+		update_outstanding_amount(frm);
+	},
+
+	is_buyback(frm) {
+		update_outstanding_amount(frm);
 	},
 	no_of_installment: function(frm) {
 		generate_emi_schedule(frm);
@@ -44,20 +59,17 @@ frappe.ui.form.on('Sales Invoice', {
 	emi_date: function(frm) {
 		generate_emi_schedule(frm);
 	},
-
-	// Triggered before saving or submitting the form
-
-	// If is_buyback is checked, subtract buyback_amount from outstanding_amount
 	validate(frm) {
-		if (frm.doc.is_buyback && frm.doc.buyback_amount) {
-			let new_outstanding = (frm.doc.outstanding_amount || 0) - frm.doc.buyback_amount;
-			frm.set_value('outstanding_amount', Math.max(new_outstanding, 0));
-		}
 		update_emi_amount(frm);
 		generate_emi_schedule(frm);
+	},
+	calculate_totals(frm) {
+		setTimeout(() => {
+			update_outstanding_amount(frm);
+		}, 200);
 	}
 });
-
+// Buyback Item child table
 frappe.ui.form.on('Buyback Item', {
 	qty(frm, cdt, cdn) {
 		calculate_row_amount(frm, cdt, cdn);
@@ -65,31 +77,75 @@ frappe.ui.form.on('Buyback Item', {
 	rate(frm, cdt, cdn) {
 		calculate_row_amount(frm, cdt, cdn);
 	},
-	buyback_items_add(frm) {
-		update_total_buyback_amount(frm);
-	},
 	buyback_items_remove(frm) {
 		update_total_buyback_amount(frm);
 	}
 });
+// Sales Invoice Items child table
+frappe.ui.form.on('Sales Invoice Item', {
+    qty(frm) {
+        frm.trigger("calculate_totals");
+    },
+    rate(frm) {
+        frm.trigger("calculate_totals");
+    },
+    amount(frm) {
+        frm.trigger("calculate_totals");
+    },
+    items_add(frm) {
+        frm.trigger("calculate_totals");
+    },
+    items_remove(frm) {
+        frm.trigger("calculate_totals");
+    }
+});
 
-// Calculate the amount for the Buyback Item row
-// and update the total buyback amount
+// Taxes child table
+frappe.ui.form.on('Sales Taxes and Charges', {
+    tax_amount(frm) {
+        frm.trigger("calculate_totals");
+    },
+    rate(frm) {
+        frm.trigger("calculate_totals");
+    },
+    taxes_add(frm) {
+        frm.trigger("calculate_totals");
+    },
+    taxes_remove(frm) {
+        frm.trigger("calculate_totals");
+    }
+});
+
+
+// Calculate Buyback Row Amount
 function calculate_row_amount(frm, cdt, cdn) {
 	let row = locals[cdt][cdn];
-	row.amount = (row.qty || 0) * (row.rate || 0);
+	row.amount = (flt(row.qty) || 0) * (flt(row.rate) || 0);
 	frm.fields_dict.buyback_items.grid.refresh();
 	update_total_buyback_amount(frm);
 }
 
-// Sum all row amounts from buyback_items
-// and set the parent field buyback_amount
+// Sum all row amounts from buyback_items_amount
 function update_total_buyback_amount(frm) {
 	let total = 0;
 	(frm.doc.buyback_items || []).forEach(row => {
-		total += row.amount || 0;
+		total += flt(row.amount || 0);
 	});
 	frm.set_value('buyback_amount', total);
+	update_outstanding_amount(frm);
+}
+
+// Calculate Outstanding Amount
+function update_outstanding_amount(frm) {
+	const total = flt(frm.doc.total || 0);
+	const taxes = flt(frm.doc.total_taxes_and_charges || 0);
+	const buyback = flt(frm.doc.buyback_amount || 0);
+
+	let outstanding = total + taxes;
+	if (frm.doc.is_buyback) {
+		outstanding -= buyback;
+	}
+	frm.set_value('outstanding_amount', Math.max(outstanding, 0));
 }
 
 // Filter customer field to show only providers when sales_type is EMI

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -5,11 +5,15 @@ frappe.ui.form.on('Sales Invoice', {
 	onload(frm) {
 		frm.fields_dict.buyback_items.grid.wrapper.on('change', function () {
 			update_total_buyback_amount(frm);
+			update_rounded_total(frm);
 		});
 		set_customer_filter(frm);
 	},
 	refresh: function (frm) {
-		update_outstanding_amount(frm);
+		if (frm.doc.docstatus === 0) {
+			update_outstanding_amount(frm);
+			update_rounded_total(frm);
+		}
 		if (!frm.is_new() && frm.doc.sales_type === "EMI") {
 			frm.add_custom_button(__('Create Finance Invoice'), function () {
 				frappe.call({
@@ -36,19 +40,23 @@ frappe.ui.form.on('Sales Invoice', {
 	},
 	total: function(frm) {
 		update_outstanding_amount(frm);
+		update_rounded_total(frm);
 		update_emi_amount(frm);
 		generate_emi_schedule(frm);
 	},
 	total_taxes_and_charges(frm) {
 		update_outstanding_amount(frm);
+		update_rounded_total(frm);
 	},
 
 	buyback_amount(frm) {
 		update_outstanding_amount(frm);
+		update_rounded_total(frm);
 	},
 
 	is_buyback(frm) {
 		update_outstanding_amount(frm);
+		update_rounded_total(frm);
 	},
 	no_of_installment: function(frm) {
 		generate_emi_schedule(frm);
@@ -66,6 +74,7 @@ frappe.ui.form.on('Sales Invoice', {
 	calculate_totals(frm) {
 		setTimeout(() => {
 			update_outstanding_amount(frm);
+			update_rounded_total(frm);
 		}, 200);
 	}
 });
@@ -133,20 +142,37 @@ function update_total_buyback_amount(frm) {
 	});
 	frm.set_value('buyback_amount', total);
 	update_outstanding_amount(frm);
+	update_rounded_total(frm);
 }
 
 // Calculate Outstanding Amount
 function update_outstanding_amount(frm) {
+    if (frm.doc.docstatus === 0) { // only allow before submit
+        const total = flt(frm.doc.total || 0);
+        const taxes = flt(frm.doc.total_taxes_and_charges || 0);
+        const buyback = flt(frm.doc.buyback_amount || 0);
+
+        let outstanding = total + taxes;
+        if (frm.doc.is_buyback) {
+            outstanding -= buyback;
+        }
+        frm.set_value('outstanding_amount', Math.max(outstanding, 0));
+    }
+}
+
+// Calculate Rounded Total
+function update_rounded_total(frm) {
 	const total = flt(frm.doc.total || 0);
 	const taxes = flt(frm.doc.total_taxes_and_charges || 0);
 	const buyback = flt(frm.doc.buyback_amount || 0);
 
-	let outstanding = total + taxes;
+	let grand_total = total + taxes;
 	if (frm.doc.is_buyback) {
-		outstanding -= buyback;
+		grand_total -= buyback;
 	}
-	frm.set_value('outstanding_amount', Math.max(outstanding, 0));
+	frm.set_value('rounded_total', Math.round(grand_total));
 }
+
 
 // Filter customer field to show only providers when sales_type is EMI
 // If selected customer is not a provider, clear it

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -22,9 +22,17 @@ def validate_buyback_fields(doc, method=None):
 	# 2. Set total buyback amount
 	doc.buyback_amount = total
 
-	# 3. Subtract buyback from outstanding amount
+	# 3.Calculate outstanding amount
+	grand_total = (doc.total or 0) + (doc.total_taxes_and_charges or 0)
 	if doc.is_buyback and doc.buyback_amount:
-		doc.outstanding_amount = max((doc.outstanding_amount or 0) - doc.buyback_amount, 0)
+		grand_total -= doc.buyback_amount
+	doc.outstanding_amount = round(grand_total)
+
+	# 4. Set rounded_total
+	grand_total = (doc.total or 0) + (doc.total_taxes_and_charges or 0)
+	if doc.is_buyback and doc.buyback_amount:
+		grand_total -= doc.buyback_amount
+	doc.rounded_total = round(grand_total)
 
 def create_scrap_stock_entry(doc, method):
 	"""


### PR DESCRIPTION
## Feature description
Need to: 

- Update logic to ensure outstanding amount is recalculated immediately when rows are added, removed, or modified in the following child tables:

       - Buyback Items
       - Items
       - Taxes and Charges

- Calculate Rounded total based on buyback amount in sales invoice.

## Solution description
- Fixed issue where adding a row to the Buyback Item table did not update the outstanding amount immediately.
- Added grid change listener on buyback_items to recalculate total buyback and outstanding amounts as values are entered.
- Ensures accurate real-time calculation when qty or rate is modified after row addition.
- Calculated Rounded total based on buyback amount in sales invoice doctype like outstanding amount procedure

## Output
[Screencast from 03-07-25 03:41:04 PM IST.webm](https://github.com/user-attachments/assets/7c0b7c33-2376-4d5a-b689-889da288d1da)

[Screencast from 03-07-25 03:42:10 PM IST.webm](https://github.com/user-attachments/assets/07cbae54-7c9d-4f31-a8f0-a927870c9fa2)

![image](https://github.com/user-attachments/assets/50a525c3-7d52-40e2-aceb-956e01c926b0)

## Areas affected and ensured
- Purchase Invoice doctype 

## Is there any existing behavior change of other features due to this code change?
- No

## Was this feature tested on the browsers?
  - Chrome