### PR TITLE
feat: Set Purchase Category into Serail and batch Bundle

### DIFF
--- a/e_mart/e_mart/custom_scripts/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/e_mart/e_mart/custom_scripts/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -21,3 +21,45 @@ def set_purchase_category_from_voucher(doc, method):
         row.purchase_category = purchase_category
 
     doc.save(ignore_permissions=True)
+
+def set_purchase_category_on_creation(doc, method=None):
+    """
+    On creation of Serial and Batch Bundle, set Purchase Category
+    in child entries if Serial No or Batch No was already used elsewhere.
+    """
+    updated = False
+
+    for entry in doc.entries:
+        if entry.purchase_category:
+            continue 
+
+        purchase_category = None
+
+        if entry.serial_no:
+            purchase_category = frappe.db.get_value(
+                "Serial and Batch Entry",
+                {
+                    "serial_no": entry.serial_no,
+                    "parent": ["!=", doc.name]
+                },
+                "purchase_category",
+                order_by="creation desc"
+            )
+
+        if not purchase_category and entry.batch_no:
+            purchase_category = frappe.db.get_value(
+                "Serial and Batch Entry",
+                {
+                    "batch_no": entry.batch_no,
+                    "parent": ["!=", doc.name]
+                },
+                "purchase_category",
+                order_by="creation desc"
+            )
+
+        if purchase_category:
+            entry.purchase_category = purchase_category
+            updated = True
+
+    if updated:
+        doc.save(ignore_permissions=True)

--- a/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
+++ b/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
@@ -10,6 +10,8 @@
   "debit_note_adjusted_account",
   "column_break_nwjy",
   "scrap_warehouse",
+  "column_break_bgwq",
+  "buyback_posting_account",
   "demo_schedule_details_tab",
   "subject",
   "task_type",
@@ -73,13 +75,23 @@
    "fieldname": "escalation_duration",
    "fieldtype": "Int",
    "label": "Escalation Duration"
+  },
+  {
+   "fieldname": "column_break_bgwq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "buyback_posting_account",
+   "fieldtype": "Link",
+   "label": "Buyback Posting Account",
+   "options": "Account"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-03 13:07:11.264626",
+ "modified": "2025-07-04 10:39:11.057244",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "E-mart Settings",

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -142,7 +142,10 @@ before_uninstall = "e_mart.setup.before_uninstall"
 
 doc_events = {
     "Serial and Batch Bundle": {
-        "on_submit": "e_mart.e_mart.custom_scripts.serial_and_batch_bundle.serial_and_batch_bundle.set_purchase_category_from_voucher"
+        "on_submit": [
+			"e_mart.e_mart.custom_scripts.serial_and_batch_bundle.serial_and_batch_bundle.set_purchase_category_from_voucher",
+			"e_mart.e_mart.custom_scripts.serial_and_batch_bundle.serial_and_batch_bundle.set_purchase_category_on_creation"
+		]	
     },
     "Purchase Receipt": {
         "before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -236,8 +236,9 @@ def get_serial_and_batch_entry_custom_fields():
                 "fieldname": "purchase_category",
                 "fieldtype": "Select",
                 "label": "Purchase Category",
-                "options": "Normal\nSpecial",
+                "options": "\nNormal\nSpecial",
                 "insert_after": "batch_no",
+				"read_only": 1,
                 "allow_on_submit": 1
             }
         ]

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -230,6 +230,7 @@ def get_sales_invoice_item_custom_fields():
                 "fieldtype": "Check",
                 "label": "Demo Required",
 				"fetch_from": "item_code.demo_required",
+				"read_only": 1,
                 "insert_after": "is_free_item"
             },
         ]

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -6,507 +6,507 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def after_install():
-    create_custom_fields(get_purchase_order_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_purchase_receipt_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_sales_order_item_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_purchase_invoice_item_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_item_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_customer_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_stock_reconciliation_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_mode_of_payment_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_purchase_order_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_purchase_receipt_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_purchase_invoice_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_sales_order_item_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_purchase_invoice_item_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_item_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_customer_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_stock_reconciliation_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_mode_of_payment_custom_fields(), ignore_validate=True, update=True)
 
-    create_property_setters(get_property_setters())
+	create_property_setters(get_property_setters())
 
 def after_migrate():
-    after_install()
+	after_install()
 
 def before_uninstall():
-    delete_custom_fields(get_purchase_order_custom_fields())
-    delete_custom_fields(get_purchase_receipt_custom_fields())
-    delete_custom_fields(get_purchase_invoice_custom_fields())
-    delete_custom_fields(get_sales_order_item_custom_fields())
-    delete_custom_fields(get_sales_invoice_item_custom_fields())
-    delete_custom_fields(get_serial_and_batch_entry_custom_fields())
-    delete_custom_fields(get_purchase_invoice_item_custom_fields())
-    delete_custom_fields(get_item_custom_fields())
-    delete_custom_fields(get_customer_custom_fields())
-    delete_custom_fields(get_stock_reconciliation_custom_fields())
-    delete_custom_fields(get_sales_invoice_custom_fields())
-    delete_custom_fields(get_task_custom_fields())
-    delete_custom_fields(get_mode_of_payment_custom_fields())
+	delete_custom_fields(get_purchase_order_custom_fields())
+	delete_custom_fields(get_purchase_receipt_custom_fields())
+	delete_custom_fields(get_purchase_invoice_custom_fields())
+	delete_custom_fields(get_sales_order_item_custom_fields())
+	delete_custom_fields(get_sales_invoice_item_custom_fields())
+	delete_custom_fields(get_serial_and_batch_entry_custom_fields())
+	delete_custom_fields(get_purchase_invoice_item_custom_fields())
+	delete_custom_fields(get_item_custom_fields())
+	delete_custom_fields(get_customer_custom_fields())
+	delete_custom_fields(get_stock_reconciliation_custom_fields())
+	delete_custom_fields(get_sales_invoice_custom_fields())
+	delete_custom_fields(get_task_custom_fields())
+	delete_custom_fields(get_mode_of_payment_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
-    """
-    Method to Delete custom fields
-    args:
-        custom_fields: a dict like `{'Task': [{fieldname: 'your_fieldname', ...}]}`
-    """
-    for doctype, fields in custom_fields.items():
-        frappe.db.delete(
-            "Custom Field",
-            {
-                "fieldname": ("in", [field["fieldname"] for field in fields]),
-                "dt": doctype,
-            },
-        )
-        frappe.clear_cache(doctype=doctype)
+	"""
+	Method to Delete custom fields
+	args:
+		custom_fields: a dict like `{'Task': [{fieldname: 'your_fieldname', ...}]}`
+	"""
+	for doctype, fields in custom_fields.items():
+		frappe.db.delete(
+			"Custom Field",
+			{
+				"fieldname": ("in", [field["fieldname"] for field in fields]),
+				"dt": doctype,
+			},
+		)
+		frappe.clear_cache(doctype=doctype)
 
 def get_purchase_order_custom_fields():
-    """
-    Custom fields that need to be added to the Purchase Order DocType
-    """
-    return {
-        "Purchase Order": [
-            {
-                "fieldname": "purchase_category",
-                "fieldtype": "Select",
-                "label": "Purchase Category",
-                "options": "Normal\nSpecial",
-                "insert_after": "is_subcontracted"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Purchase Order DocType
+	"""
+	return {
+		"Purchase Order": [
+			{
+				"fieldname": "purchase_category",
+				"fieldtype": "Select",
+				"label": "Purchase Category",
+				"options": "Normal\nSpecial",
+				"insert_after": "is_subcontracted"
+			}
+		]
+	}
 
 def get_purchase_receipt_custom_fields():
-    """
-    Custom fields that need to be added to the Purchase Receipt DocType
-    """
-    return {
-        "Purchase Receipt": [
-            {
-                "fieldname": "purchase_category",
-                "fieldtype": "Select",
-                "label": "Purchase Category",
-                "options": "Normal\nSpecial",
-                "insert_after": "is_return"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Purchase Receipt DocType
+	"""
+	return {
+		"Purchase Receipt": [
+			{
+				"fieldname": "purchase_category",
+				"fieldtype": "Select",
+				"label": "Purchase Category",
+				"options": "Normal\nSpecial",
+				"insert_after": "is_return"
+			}
+		]
+	}
 
 def get_purchase_invoice_custom_fields():
-    """
-    Custom fields that need to be added to the Purchase Invoice DocType
-    """
-    return {
-        "Purchase Invoice": [
-            {
-                "fieldname": "purchase_category",
-                "fieldtype": "Select",
-                "label": "Purchase Category",
-                "options": "Normal\nSpecial",
-                "insert_after": "apply_tds"
-            },
-            {
-                "fieldname": "purchase_schema",
-                "fieldtype": "Select",
-                "label": "Purchase Schema",
-                "options": "Item-wise\nInvoice-level",
-                "insert_after": "supplier"
-            },
-            {
-                "fieldname": "schema_discount_amount",
-                "fieldtype": "Currency",
-                "label": "Schema Discount Amount",
-                "insert_after": "items",
-                "read_only_depends_on": "eval:doc.purchase_schema == 'Item-wise'"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Purchase Invoice DocType
+	"""
+	return {
+		"Purchase Invoice": [
+			{
+				"fieldname": "purchase_category",
+				"fieldtype": "Select",
+				"label": "Purchase Category",
+				"options": "Normal\nSpecial",
+				"insert_after": "apply_tds"
+			},
+			{
+				"fieldname": "purchase_schema",
+				"fieldtype": "Select",
+				"label": "Purchase Schema",
+				"options": "Item-wise\nInvoice-level",
+				"insert_after": "supplier"
+			},
+			{
+				"fieldname": "schema_discount_amount",
+				"fieldtype": "Currency",
+				"label": "Schema Discount Amount",
+				"insert_after": "items",
+				"read_only_depends_on": "eval:doc.purchase_schema == 'Item-wise'"
+			}
+		]
+	}
 
 def get_purchase_invoice_item_custom_fields():
-    """
-    Custom fields that need to be added to the Purchase Invoice Item DocType
-    """
-    return {
-        "Purchase Invoice Item": [
-            {
-                "fieldname": "schema_discount_amount",
-                "fieldtype": "Currency",
-                "label": "Schema Discount Amount",
-                "insert_after": "amount"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Purchase Invoice Item DocType
+	"""
+	return {
+		"Purchase Invoice Item": [
+			{
+				"fieldname": "schema_discount_amount",
+				"fieldtype": "Currency",
+				"label": "Schema Discount Amount",
+				"insert_after": "amount"
+			}
+		]
+	}
 
 def get_item_custom_fields():
-    """
-    Custom fields that need to be added to the Item DocType
-    """
-    return {
-        "Item": [
-            {
-                "fieldname": "sales_commission",
-                "fieldtype": "Select",
-                "label": "Sales Commission",
-                "options": "Percentage\nFixed",
-                "insert_after": "max_discount"
-            },
-            {
-                "fieldname": "commission_value",
-                "fieldtype": "Float",
-                "label": "Commission Value",
-                "insert_after": "sales_commission"
-            },
-            {
-                "fieldname": "demo_required",
-                "fieldtype": "Check",
-                "label": "Demo Required",
-                "insert_after": "allow_negative_stock"
-            },
-            {
-                "fieldname": "periodic_service",
-                "fieldtype": "Check",
-                "label": "Periodic Service",
-                "insert_after": "demo_required"
-            },
-            {
-                "fieldname": "mrp",
-                "fieldtype": "Float",
-                "label": "MRP",
-                "insert_after": "stock_uom"
-            },
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Item DocType
+	"""
+	return {
+		"Item": [
+			{
+				"fieldname": "sales_commission",
+				"fieldtype": "Select",
+				"label": "Sales Commission",
+				"options": "Percentage\nFixed",
+				"insert_after": "max_discount"
+			},
+			{
+				"fieldname": "commission_value",
+				"fieldtype": "Float",
+				"label": "Commission Value",
+				"insert_after": "sales_commission"
+			},
+			{
+				"fieldname": "demo_required",
+				"fieldtype": "Check",
+				"label": "Demo Required",
+				"insert_after": "allow_negative_stock"
+			},
+			{
+				"fieldname": "periodic_service",
+				"fieldtype": "Check",
+				"label": "Periodic Service",
+				"insert_after": "demo_required"
+			},
+			{
+				"fieldname": "mrp",
+				"fieldtype": "Float",
+				"label": "MRP",
+				"insert_after": "stock_uom"
+			},
+		]
+	}
 
 def get_customer_custom_fields():
-    """
-    Custom fields that need to be added to the Customer DocType
-    """
-    return {
-        "Customer": [
-            {
-                "fieldname": "is_provider",
-                "fieldtype": "Check",
-                "label": "Is Provider",
-                "insert_after": "customer_group"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Customer DocType
+	"""
+	return {
+		"Customer": [
+			{
+				"fieldname": "is_provider",
+				"fieldtype": "Check",
+				"label": "Is Provider",
+				"insert_after": "customer_group"
+			}
+		]
+	}
 
 def get_sales_order_item_custom_fields():
-    """
-    Custom fields that need to be added to the Sales Order Item DocType
-    """
-    return {
-        "Sales Order Item": [
-            {
-                "fieldname": "allow_commission",
-                "fieldtype": "Check",
-                "label": "Allow Commission",
-                "insert_after": "item_tax_template"
-            },
-            {
-                "fieldname": "profit_for_commission",
-                "fieldtype": "Currency",
-                "label": "Profit for Commission",
-                "insert_after": "allow_commission"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Sales Order Item DocType
+	"""
+	return {
+		"Sales Order Item": [
+			{
+				"fieldname": "allow_commission",
+				"fieldtype": "Check",
+				"label": "Allow Commission",
+				"insert_after": "item_tax_template"
+			},
+			{
+				"fieldname": "profit_for_commission",
+				"fieldtype": "Currency",
+				"label": "Profit for Commission",
+				"insert_after": "allow_commission"
+			}
+		]
+	}
 
 def get_sales_invoice_item_custom_fields():
-    """
-    Custom fields that need to be added to the Sales Invoice Item DocType
-    """
-    return {
-        "Sales Invoice Item": [
-            {
-                "fieldname": "allow_commission",
-                "fieldtype": "Check",
-                "label": "Allow Commission",
-                "insert_after": "item_tax_template"
-            },
-            {
-                "fieldname": "profit_for_commission",
-                "fieldtype": "Currency",
-                "label": "Profit for Commission",
-                "insert_after": "allow_commission"
-            },
+	"""
+	Custom fields that need to be added to the Sales Invoice Item DocType
+	"""
+	return {
+		"Sales Invoice Item": [
 			{
-                "fieldname": "is_demo_reqd",
-                "fieldtype": "Check",
-                "label": "Demo Required",
+				"fieldname": "allow_commission",
+				"fieldtype": "Check",
+				"label": "Allow Commission",
+				"insert_after": "item_tax_template"
+			},
+			{
+				"fieldname": "profit_for_commission",
+				"fieldtype": "Currency",
+				"label": "Profit for Commission",
+				"insert_after": "allow_commission"
+			},
+			{
+				"fieldname": "is_demo_reqd",
+				"fieldtype": "Check",
+				"label": "Demo Required",
 				"fetch_from": "item_code.demo_required",
 				"read_only": 1,
-                "insert_after": "is_free_item"
-            },
-        ]
-    }
+				"insert_after": "is_free_item"
+			},
+		]
+	}
 
 def get_serial_and_batch_entry_custom_fields():
-    """
-    Custom fields that need to be added to the Serial and Batch Entry DocType
-    """
-    return {
-        "Serial and Batch Entry": [
-            {
-                "fieldname": "purchase_category",
-                "fieldtype": "Select",
-                "label": "Purchase Category",
-                "options": "\nNormal\nSpecial",
-                "insert_after": "batch_no",
+	"""
+	Custom fields that need to be added to the Serial and Batch Entry DocType
+	"""
+	return {
+		"Serial and Batch Entry": [
+			{
+				"fieldname": "purchase_category",
+				"fieldtype": "Select",
+				"label": "Purchase Category",
+				"options": "\nNormal\nSpecial",
+				"insert_after": "batch_no",
 				"read_only": 1,
-                "allow_on_submit": 1
-            }
-        ]
-    }
+				"allow_on_submit": 1
+			}
+		]
+	}
 
 def get_stock_reconciliation_custom_fields():
-    """
-    Custom fields that need to be added to the Stock Reconciliation DocType
-    """
-    return {
-        "Stock Reconciliation": [
-            {
-                "fieldname": "purchase_category",
-                "fieldtype": "Select",
-                "label": "Purchase Category",
-                "options": "Normal\nSpecial",
-                "insert_after": "set_posting_time"
-            }
-        ]
-    }
+	"""
+	Custom fields that need to be added to the Stock Reconciliation DocType
+	"""
+	return {
+		"Stock Reconciliation": [
+			{
+				"fieldname": "purchase_category",
+				"fieldtype": "Select",
+				"label": "Purchase Category",
+				"options": "Normal\nSpecial",
+				"insert_after": "set_posting_time"
+			}
+		]
+	}
 
 def get_mode_of_payment_custom_fields():
-    """
-    Custom fields that need to be added to the Mode Of Payment DocType
-    """
-    return {
-        "Mode of Payment": [
-            {
-                "fieldname": "is_finance",
-                "fieldtype": "Check",
-                "label": "Is Finance",
-                "insert_after": "enabled"
-            }
-        ]
-    }	
+	"""
+	Custom fields that need to be added to the Mode Of Payment DocType
+	"""
+	return {
+		"Mode of Payment": [
+			{
+				"fieldname": "is_finance",
+				"fieldtype": "Check",
+				"label": "Is Finance",
+				"insert_after": "enabled"
+			}
+		]
+	}	
 
 def get_task_custom_fields():
-    """
-    Custom fields that need to be added to the Task DocType
-    """
-    return {
-        "Task": [
+	"""
+	Custom fields that need to be added to the Task DocType
+	"""
+	return {
+		"Task": [
 			{
-                "fieldname": "section_break_l",
-                "fieldtype": "Section Break",
-                "label": "Invoice Details",
-                "insert_after": "parent_task",
+				"fieldname": "section_break_l",
+				"fieldtype": "Section Break",
+				"label": "Invoice Details",
+				"insert_after": "parent_task",
 				"collapsible": 1
-            },
-            {
-                "fieldname": "invoice_reference",
-                "fieldtype": "Link",
-                "label": "Sales Invoice",
+			},
+			{
+				"fieldname": "invoice_reference",
+				"fieldtype": "Link",
+				"label": "Sales Invoice",
 				"options": "Sales Invoice",
 				"read_only": 1,
-                "insert_after": "section_break_l"
-            },
+				"insert_after": "section_break_l"
+			},
 			{
-                "fieldname": "invoice_date",
-                "fieldtype": "Date",
-                "label": "Invoice Date",
+				"fieldname": "invoice_date",
+				"fieldtype": "Date",
+				"label": "Invoice Date",
 				"read_only": 1,
-                "insert_after": "invoice_reference"
-            },
+				"insert_after": "invoice_reference"
+			},
 			{
-                "fieldname": "column_break_task",
-                "fieldtype": "Column Break",
-                "label": " ",
-                "insert_after": "invoice_date",
+				"fieldname": "column_break_task",
+				"fieldtype": "Column Break",
+				"label": " ",
+				"insert_after": "invoice_date",
 				"collapsible": 1
-            },
+			},
 			{
-                "fieldname": "customer",
-                "fieldtype": "Link",
-                "label": "Customer",
+				"fieldname": "customer",
+				"fieldtype": "Link",
+				"label": "Customer",
 				"options": "Customer",
 				"read_only": 1,
-                "insert_after": "column_break_task"
-            },
-        ]
-    }	
+				"insert_after": "column_break_task"
+			},
+		]
+	}	
 
 def create_property_setters(property_setter_datas):
-    '''
-    Method to create custom property setters
-    args:
-        property_setter_datas : list of dict of property setter obj
-    '''
-    for property_setter_data in property_setter_datas:
-        if frappe.db.exists("Property Setter", property_setter_data):
-            continue
-        property_setter = frappe.new_doc("Property Setter")
-        property_setter.update(property_setter_data)
-        property_setter.flags.ignore_permissions = True
-        property_setter.insert()
+	'''
+	Method to create custom property setters
+	args:
+		property_setter_datas : list of dict of property setter obj
+	'''
+	for property_setter_data in property_setter_datas:
+		if frappe.db.exists("Property Setter", property_setter_data):
+			continue
+		property_setter = frappe.new_doc("Property Setter")
+		property_setter.update(property_setter_data)
+		property_setter.flags.ignore_permissions = True
+		property_setter.insert()
 
 def get_property_setters():
-    '''
-     specific property setters that need to be added to the DocTypes
-    '''
-    return [
-        {
-            "doctype_or_field": "DocField",
-            "doc_type": "Sales Invoice Item",
-            "field_name": "grant_commission",
-            "property": "hidden",
-            "value": 1
-        },
-        {
-            "doctype_or_field": "DocField",
-            "doc_type": "Sales Order Item",
-            "field_name": "grant_commission",
-            "property": "hidden",
-            "value": 1
-        }
-    ]
+	'''
+	 specific property setters that need to be added to the DocTypes
+	'''
+	return [
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Sales Invoice Item",
+			"field_name": "grant_commission",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Sales Order Item",
+			"field_name": "grant_commission",
+			"property": "hidden",
+			"value": 1
+		}
+	]
 def get_sales_invoice_custom_fields():
-    """
-    Custom fields that need to be added to the Sales Invoice DocType
-    """
-    return {
-        "Sales Invoice": [
-            {
-                "fieldname": "sales_type",
-                "fieldtype": "Select",
-                "label": "Sales Type",
-                "options": "Cash\nCredit\nEMI",
-                "insert_after": "naming_series"
-            },
-            {
-                "fieldname": "mode_of_payment",
-                "fieldtype": "Link",
-                "label": "Mode Of Payment",
-                "options": "Mode of Payment",
-                "insert_after": "customer"
-            },
-            {
-                "fieldname": "is_buyback",
-                "fieldtype": "Check",
-                "label": "Is Buyback",
-                "insert_after": "mode_of_payment"
-            },
-            {
-                "fieldname": "buyback_section",
-                "fieldtype": "Section Break",
-                "label": "",
-                "insert_after": "total_taxes_and_charges"
-            },
-            {
-                "fieldname": "buyback_items",
-                "fieldtype": "Table",
-                "label": "Buyback Items",
-                "options": "Buyback Item",
-                "insert_after": "buyback_section",
-                "depends_on": "eval:doc.is_buyback"
-            },
-            {
-                "fieldname": "buyback_amount_section",
-                "fieldtype": "Section Break",
-                "label": "",
-                "insert_after": "buyback_items",
-                "depends_on": "eval:doc.is_buyback"
-            },
-            {
-                "fieldname": "buyback_column_break",
-                "fieldtype": "Column Break",
-                "insert_after": "buyback_amount_section"
-            },
-            {
-                "fieldname": "buyback_items_column_break",
-                "fieldtype": "Column Break",
-                "insert_after": "buyback_column_break"
-            },
-            {
-                "fieldname": "buyback_amount",
-                "fieldtype": "Currency",
-                "label": "Buyback Amount",
-                "insert_after": "buyback_items_column_break"
-            },
-            {
-                "fieldname": "emi_details_section",
-                "fieldtype": "Tab Break",
-                "label": "EMI Details",
-                "insert_after": "to_date",
-                "depends_on": "eval:doc.sales_type == 'EMI'"
+	"""
+	Custom fields that need to be added to the Sales Invoice DocType
+	"""
+	return {
+		"Sales Invoice": [
+			{
+				"fieldname": "sales_type",
+				"fieldtype": "Select",
+				"label": "Sales Type",
+				"options": "Cash\nCredit\nEMI",
+				"insert_after": "naming_series"
+			},
+			{
+				"fieldname": "mode_of_payment",
+				"fieldtype": "Link",
+				"label": "Mode Of Payment",
+				"options": "Mode of Payment",
+				"insert_after": "customer"
+			},
+			{
+				"fieldname": "is_buyback",
+				"fieldtype": "Check",
+				"label": "Is Buyback",
+				"insert_after": "mode_of_payment"
+			},
+			{
+				"fieldname": "buyback_section",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "total_taxes_and_charges"
+			},
+			{
+				"fieldname": "buyback_items",
+				"fieldtype": "Table",
+				"label": "Buyback Items",
+				"options": "Buyback Item",
+				"insert_after": "buyback_section",
+				"depends_on": "eval:doc.is_buyback"
+			},
+			{
+				"fieldname": "buyback_amount_section",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "buyback_items",
+				"depends_on": "eval:doc.is_buyback"
+			},
+			{
+				"fieldname": "buyback_column_break",
+				"fieldtype": "Column Break",
+				"insert_after": "buyback_amount_section"
+			},
+			{
+				"fieldname": "buyback_items_column_break",
+				"fieldtype": "Column Break",
+				"insert_after": "buyback_column_break"
+			},
+			{
+				"fieldname": "buyback_amount",
+				"fieldtype": "Currency",
+				"label": "Buyback Amount",
+				"insert_after": "buyback_items_column_break"
+			},
+			{
+				"fieldname": "emi_details_section",
+				"fieldtype": "Tab Break",
+				"label": "EMI Details",
+				"insert_after": "to_date",
+				"depends_on": "eval:doc.sales_type == 'EMI'"
 
-            },
-            {
-                "fieldname": "down_payment_amount",
-                "fieldtype": "Currency",
-                "label": "Down Payment Amount",
-                "insert_after": "down_payment",
+			},
+			{
+				"fieldname": "down_payment_amount",
+				"fieldtype": "Currency",
+				"label": "Down Payment Amount",
+				"insert_after": "down_payment",
 				"depends_on": "eval:doc.down_payment"
-            },
-            {
-                "fieldname": "emi_amount",
-                "fieldtype": "Currency",
-                "label": "EMI AMOUNT",
-                "insert_after": "down_payment_amount"
-            },
+			},
 			{
-                "fieldname": "emi_date",
-                "fieldtype": "Date",
-                "label": "EMI Start Date",
-                "insert_after": "emi_amount"
-            },
+				"fieldname": "emi_amount",
+				"fieldtype": "Currency",
+				"label": "EMI AMOUNT",
+				"insert_after": "down_payment_amount"
+			},
 			{
-                "fieldname": "emi_paid_amount",
-                "fieldtype": "Currency",
-                "label": "EMI Paid Amount",
-                "insert_after": "emi_date",
+				"fieldname": "emi_date",
+				"fieldtype": "Date",
+				"label": "EMI Start Date",
+				"insert_after": "emi_amount"
+			},
+			{
+				"fieldname": "emi_paid_amount",
+				"fieldtype": "Currency",
+				"label": "EMI Paid Amount",
+				"insert_after": "emi_date",
 				"read_only": 1
-            },
-            {
-                "fieldname": "installment_column_break",
-                "fieldtype": "Column Break",
-                "insert_after": "emi_paid_amount"
-            },
-            {
-                "fieldname": "no_of_installment",
-                "fieldtype": "Int",
-                "label": "No Of Installment",
-                "insert_after": "installment_column_break"
-            },
-            {
-                "fieldname": "emi_duration_section",
-                "fieldtype": "Section Break",
-                "label": "EMI Schedule",
-                "insert_after": "closing_date",
-                "depends_on": "eval:doc.sales_type == 'EMI'"
+			},
+			{
+				"fieldname": "installment_column_break",
+				"fieldtype": "Column Break",
+				"insert_after": "emi_paid_amount"
+			},
+			{
+				"fieldname": "no_of_installment",
+				"fieldtype": "Int",
+				"label": "No Of Installment",
+				"insert_after": "installment_column_break"
+			},
+			{
+				"fieldname": "emi_duration_section",
+				"fieldtype": "Section Break",
+				"label": "EMI Schedule",
+				"insert_after": "closing_date",
+				"depends_on": "eval:doc.sales_type == 'EMI'"
 
-            },
-            {
-                "fieldname": "emi_duration",
-                "fieldtype": "Table",
-                "label": "EMI Schedule",
-                "options":"EMI Duration",
-                "insert_after": "emi_duration_section"
-            },
+			},
 			{
-                "fieldname": "down_payment",
-                "fieldtype": "Check",
-                "label": "Is Down Payment",
-                "insert_after": "emi_details_section"
-            },
+				"fieldname": "emi_duration",
+				"fieldtype": "Table",
+				"label": "EMI Schedule",
+				"options":"EMI Duration",
+				"insert_after": "emi_duration_section"
+			},
 			{
-                "fieldname": "down_payment_paid",
-                "fieldtype": "Check",
-                "label": "Down Payment Paid",
-                "insert_after": "no_of_installment"
-            },
+				"fieldname": "down_payment",
+				"fieldtype": "Check",
+				"label": "Is Down Payment",
+				"insert_after": "emi_details_section"
+			},
 			{
-                "fieldname": "closing_date",
-                "fieldtype": "Date",
-                "label": "Closing Date",
-                "insert_after": "emi_status"
-            }        
-        ]
-    }
+				"fieldname": "down_payment_paid",
+				"fieldtype": "Check",
+				"label": "Down Payment Paid",
+				"insert_after": "no_of_installment"
+			},
+			{
+				"fieldname": "closing_date",
+				"fieldtype": "Date",
+				"label": "Closing Date",
+				"insert_after": "emi_status"
+			}        
+		]
+	}

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -440,10 +440,17 @@ def get_sales_invoice_custom_fields():
                 "label": "EMI Start Date",
                 "insert_after": "emi_amount"
             },
+			{
+                "fieldname": "emi_paid_amount",
+                "fieldtype": "Currency",
+                "label": "EMI Paid Amount",
+                "insert_after": "emi_date",
+				"read_only": 1
+            },
             {
                 "fieldname": "installment_column_break",
                 "fieldtype": "Column Break",
-                "insert_after": "emi_date"
+                "insert_after": "emi_paid_amount"
             },
             {
                 "fieldname": "no_of_installment",

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -18,6 +18,7 @@ def after_install():
     create_custom_fields(get_stock_reconciliation_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_mode_of_payment_custom_fields(), ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -37,6 +38,7 @@ def before_uninstall():
     delete_custom_fields(get_stock_reconciliation_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
     delete_custom_fields(get_task_custom_fields())
+    delete_custom_fields(get_mode_of_payment_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     """
@@ -270,6 +272,21 @@ def get_stock_reconciliation_custom_fields():
         ]
     }
 
+def get_mode_of_payment_custom_fields():
+    """
+    Custom fields that need to be added to the Mode Of Payment DocType
+    """
+    return {
+        "Mode of Payment": [
+            {
+                "fieldname": "is_finance",
+                "fieldtype": "Check",
+                "label": "Is Finance",
+                "insert_after": "enabled"
+            }
+        ]
+    }	
+
 def get_task_custom_fields():
     """
     Custom fields that need to be added to the Task DocType
@@ -364,18 +381,17 @@ def get_sales_invoice_custom_fields():
                 "insert_after": "naming_series"
             },
             {
-                "fieldname": "actual_customer",
+                "fieldname": "mode_of_payment",
                 "fieldtype": "Link",
-                "label": "Actual Customer",
-                "options": "Customer",
-                "depends_on": "eval:doc.sales_type == 'EMI' && doc.customer",
+                "label": "Mode Of Payment",
+                "options": "Mode of Payment",
                 "insert_after": "customer"
             },
             {
                 "fieldname": "is_buyback",
                 "fieldtype": "Check",
                 "label": "Is Buyback",
-                "insert_after": "actual_customer"
+                "insert_after": "mode_of_payment"
             },
             {
                 "fieldname": "buyback_section",
@@ -416,9 +432,9 @@ def get_sales_invoice_custom_fields():
             },
             {
                 "fieldname": "emi_details_section",
-                "fieldtype": "Section Break",
+                "fieldtype": "Tab Break",
                 "label": "EMI Details",
-                "insert_after": "total",
+                "insert_after": "to_date",
                 "depends_on": "eval:doc.sales_type == 'EMI'"
 
             },
@@ -481,10 +497,9 @@ def get_sales_invoice_custom_fields():
                 "insert_after": "emi_details_section"
             },
 			{
-                "fieldname": "emi_status",
-                "fieldtype": "Select",
-                "label": "EMI Status",
-				"options": "Unpaid\nPartly Paid\nPaid",
+                "fieldname": "down_payment_paid",
+                "fieldtype": "Check",
+                "label": "Down Payment Paid",
                 "insert_after": "no_of_installment"
             },
 			{

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -12,11 +12,12 @@ def after_install():
     create_custom_fields(get_sales_order_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_sales_invoice_item_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_serial_and_batch_entry_custom_fields(), ignore_validate=True, update=True)
-    create_custom_fields(get_purchase_invoice_item_custom_fields(),ignore_validate=True, update=True)
-    create_custom_fields(get_item_custom_fields(),ignore_validate=True, update=True)
-    create_custom_fields(get_customer_custom_fields(),ignore_validate=True, update=True)
-    create_custom_fields(get_stock_reconciliation_custom_fields(),ignore_validate=True, update=True)
+    create_custom_fields(get_purchase_invoice_item_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_item_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_customer_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_stock_reconciliation_custom_fields(), ignore_validate=True, update=True)
     create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
+    create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
 
     create_property_setters(get_property_setters())
 
@@ -35,6 +36,7 @@ def before_uninstall():
     delete_custom_fields(get_customer_custom_fields())
     delete_custom_fields(get_stock_reconciliation_custom_fields())
     delete_custom_fields(get_sales_invoice_custom_fields())
+    delete_custom_fields(get_task_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
     """
@@ -222,7 +224,14 @@ def get_sales_invoice_item_custom_fields():
                 "fieldtype": "Currency",
                 "label": "Profit for Commission",
                 "insert_after": "allow_commission"
-            }
+            },
+			{
+                "fieldname": "is_demo_reqd",
+                "fieldtype": "Check",
+                "label": "Demo Required",
+				"fetch_from": "item_code.demo_required",
+                "insert_after": "is_free_item"
+            },
         ]
     }
 
@@ -260,6 +269,52 @@ def get_stock_reconciliation_custom_fields():
         ]
     }
 
+def get_task_custom_fields():
+    """
+    Custom fields that need to be added to the Task DocType
+    """
+    return {
+        "Task": [
+			{
+                "fieldname": "section_break_l",
+                "fieldtype": "Section Break",
+                "label": "Invoice Details",
+                "insert_after": "parent_task",
+				"collapsible": 1
+            },
+            {
+                "fieldname": "invoice_reference",
+                "fieldtype": "Link",
+                "label": "Sales Invoice",
+				"options": "Sales Invoice",
+				"read_only": 1,
+                "insert_after": "section_break_l"
+            },
+			{
+                "fieldname": "invoice_date",
+                "fieldtype": "Date",
+                "label": "Invoice Date",
+				"read_only": 1,
+                "insert_after": "invoice_reference"
+            },
+			{
+                "fieldname": "column_break_task",
+                "fieldtype": "Column Break",
+                "label": " ",
+                "insert_after": "invoice_date",
+				"collapsible": 1
+            },
+			{
+                "fieldname": "customer",
+                "fieldtype": "Link",
+                "label": "Customer",
+				"options": "Customer",
+				"read_only": 1,
+                "insert_after": "column_break_task"
+            },
+        ]
+    }	
+
 def create_property_setters(property_setter_datas):
     '''
     Method to create custom property setters
@@ -295,6 +350,9 @@ def get_property_setters():
         }
     ]
 def get_sales_invoice_custom_fields():
+    """
+    Custom fields that need to be added to the Sales Invoice DocType
+    """
     return {
         "Sales Invoice": [
             {


### PR DESCRIPTION
## Feature description
- Update Purchase category into Serial and batch bundle.

## Solution description
- Updated Purchase category into Serial and batch bundle.
- Added custom fields in Task and Sales Invoice Item.

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/368b34ed-804d-4457-9c1a-393757627a47)

## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla Firefox
