### PR TITLE
feat:sales invoice map to payment entry

### DIFF
--- a/e_mart/e_mart/custom_scripts/payment_entry/payment_entry.py
+++ b/e_mart/e_mart/custom_scripts/payment_entry/payment_entry.py
@@ -1,0 +1,18 @@
+
+import frappe
+
+def update_down_payment_status(doc, method):
+	"""
+	On Payment Entry Submit:
+	If fully paid down payment for Sales Invoice, mark down_payment_paid = 1.
+	"""
+	for ref in doc.references:
+		if ref.reference_doctype == "Sales Invoice":
+			si_name = ref.reference_name
+
+			down_payment = frappe.db.get_value("Sales Invoice", si_name, "down_payment")
+			down_payment_amount = frappe.db.get_value("Sales Invoice", si_name, "down_payment_amount")
+
+			if down_payment and down_payment_amount and doc.paid_amount == down_payment_amount:
+				frappe.db.set_value("Sales Invoice", si_name, "down_payment_paid", 1)
+

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -7,22 +7,30 @@ frappe.ui.form.on('Sales Invoice', {
 		set_customer_filter(frm);
 	},
 	refresh: function (frm) {
-        if (!frm.is_new() && frm.doc.sales_type === "EMI") {
-            frm.add_custom_button(__('Create Finance Invoice'), function () {
-                frappe.call({
-                    method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_finance_invoice",
-                    args: {
-                        sales_invoice_name: frm.doc.name
-                    },
-                    callback: function (r) {
-                        if (r.message) {
-                            frappe.set_route('Form', 'Finance Invoice', r.message);
-                        }
-                    }
-                });
-            });
-        }
-    },
+		if (!frm.is_new() && frm.doc.sales_type === "EMI") {
+			frm.add_custom_button(__('Create Finance Invoice'), function () {
+				frappe.call({
+					method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_finance_invoice",
+					args: {
+						sales_invoice_name: frm.doc.name
+					},
+					callback: function (r) {
+						if (r.message) {
+							frappe.set_route('Form', 'Finance Invoice', r.message);
+						}
+					}
+				});
+			});
+		if (frm.doc.docstatus === 1 && frm.doc.down_payment && frm.doc.down_payment_amount) {
+			frm.add_custom_button(__('Down Payment'), function() {
+				frappe.model.open_mapped_doc({
+					method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.make_down_payment_entry",
+					source_name: frm.doc.name  
+				});
+			}, __('Create'));
+		}
+	}
+},
 	sales_type(frm) {
 		set_customer_filter(frm);
 	},

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -1,5 +1,7 @@
 import frappe
 from frappe.utils import flt,add_months
+from frappe.model.mapper import get_mapped_doc
+
 
 def validate_buyback_fields(doc, method=None):
 
@@ -78,6 +80,8 @@ def generate_emi_schedule(doc, method):
 	"""
 	if doc.sales_type != "EMI":
 		return
+	if doc.is_buyback: 
+		return
 
 	if not doc.emi_date:
 		frappe.throw("Please set the EMI Start Date in Sales Invoice.")
@@ -136,3 +140,58 @@ def create_finance_invoice(sales_invoice_name):
 
 	return finance_invoice.name
 
+#
+@frappe.whitelist()
+
+def make_down_payment_entry(source_name, target_doc=None):
+	def set_missing_values(source, target):
+		"""
+		Create a Payment Entry from a Sales Invoice for down payment.
+		Replaces total payment with down payment amount and map hte details.
+		
+		"""
+		down_payment = source.down_payment_amount
+		target.payment_type = "Receive"
+		target.party_type = "Customer"
+		target.paid_amount = down_payment
+		target.received_amount = down_payment
+
+		paid_from = frappe.get_value("Company", source.company, "default_receivable_account")
+		paid_to = frappe.get_value("Company", source.company, "default_bank_account")
+
+		target.paid_from = paid_from
+		target.paid_to = paid_to
+		target.posting_date = frappe.utils.nowdate()
+
+		paid_from_currency = frappe.get_value("Account", paid_from, "account_currency")
+		paid_to_currency = frappe.get_value("Account", paid_to, "account_currency")
+
+		target.paid_from_account_currency = paid_from_currency
+		target.paid_to_account_currency = paid_to_currency
+
+		target.append("references", {
+			"reference_doctype": "Sales Invoice",
+			"reference_name": source.name,
+			"total_amount": source.rounded_total,
+			"outstanding_amount": source.outstanding_amount,
+			"allocated_amount": down_payment
+		})
+
+	doc = get_mapped_doc(
+		"Sales Invoice",
+		source_name,
+		{
+			"Sales Invoice": {
+				"doctype": "Payment Entry",
+				"field_map": {
+					"customer": "party",
+					"customer_name": "party_name",
+					"company": "company"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
+	return doc
+	

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -141,31 +141,31 @@ before_uninstall = "e_mart.setup.before_uninstall"
 # Hook on document methods and events
 
 doc_events = {
-    "Serial and Batch Bundle": {
-        "on_submit": [
+	"Serial and Batch Bundle": {
+		"on_submit": [
 			"e_mart.e_mart.custom_scripts.serial_and_batch_bundle.serial_and_batch_bundle.set_purchase_category_from_voucher",
 			"e_mart.e_mart.custom_scripts.serial_and_batch_bundle.serial_and_batch_bundle.set_purchase_category_on_creation"
 		]	
-    },
-    "Purchase Receipt": {
-        "before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"
-    },
-    "Purchase Invoice": {
-        "before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount",
-        "on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
-    },
-    "Sales Invoice": {
-         "validate":[
-              "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
-              "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule"
-               ],
-         "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry",
-         "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
-    },
+	},
+	"Purchase Receipt": {
+		"before_insert": "e_mart.e_mart.custom_scripts.purchase_order.purchase_order.fetch_purchase_category"
+	},
+	"Purchase Invoice": {
+		"before_save": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.update_schema_discount_amount",
+		"on_submit": "e_mart.e_mart.custom_scripts.purchase_invoice.purchase_invoice.on_submit"
+	},
+	"Sales Invoice": {
+		 "validate":[
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule"
+			   ],
+		 "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry",
+		 "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+	},
 	"Payment Entry" : {
 		"on_submit" : "e_mart.e_mart.custom_scripts.payment_entry.payment_entry.update_down_payment_status"
 	}
-    
+	
 }
 
 # Scheduled Tasks

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -161,8 +161,10 @@ doc_events = {
                ],
          "on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.create_scrap_stock_entry",
          "before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
-
-    }
+    },
+	"Payment Entry" : {
+		"on_submit" : "e_mart.e_mart.custom_scripts.payment_entry.payment_entry.update_down_payment_status"
+	}
     
 }
 

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -500,7 +500,9 @@ def get_sales_invoice_custom_fields():
 				"fieldname": "down_payment_paid",
 				"fieldtype": "Check",
 				"label": "Down Payment Paid",
-				"insert_after": "no_of_installment"
+				"insert_after": "no_of_installment",
+				"allow_on_submit" : 1 ,
+				"read_only": 1,
 			},
 			{
 				"fieldname": "closing_date",


### PR DESCRIPTION
Feature description
Mapped sales invoice to payment entry to pay down payment

Solution description
Down payment amount , customer , party are mapped to payment entry.
Created a check box read only when the payment is done it will auto check 

Output screenshots (optional)
![Screenshot from 2025-07-04 11-57-19](https://github.com/user-attachments/assets/bf08ef4c-b536-4962-b3c8-87d2ae8a9e6c)
![Screenshot from 2025-07-04 11-57-09](https://github.com/user-attachments/assets/509db8f6-9c25-4a99-87ed-b2cb0d2c3671)

Is there any existing behaviour change of other features due to this code change?
No

Was this feature tested on the browsers?
Chrome