### PR TITLE
feat: Calculated incentives based on commission in sales team table

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -294,3 +294,21 @@ function calculate_total_expense(frm) {
 	});
 	frm.set_value('total_expense', total);
 }
+
+// calculate incentives based on commission rate and allocated percentage
+frappe.ui.form.on("Sales Team", {
+	allocated_percentage: function(frm, cdt, cdn) {
+		setTimeout(function() {
+			var sales_person = frappe.get_doc(cdt, cdn);
+			let row = locals[cdt][cdn];
+			if (sales_person.allocated_percentage) {
+				sales_person.allocated_percentage = sales_person.allocated_percentage;
+				sales_person.allocated_amount = frm.doc.total_commission_rate;
+				sales_person.incentives = flt(
+					(sales_person.allocated_amount * row.allocated_percentage) / 100.0,
+				);
+				frm.refresh_field('sales_team');
+			}
+		}, 20);
+	}
+});

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -365,3 +365,13 @@ def calculate_total_expense(doc, method):
 	for row in doc.get("sales_expenses", []):
 		total += flt(row.amount or 0)
 	doc.total_expense = total
+
+# calculate incentives based on commission rate and allocated percentage
+def map_commission_to_sales_team(doc, method):
+	"""Fetch total_commission_rate to each sales_team row as allocated_amount and compute incentives."""
+	commission_rate = doc.total_commission_rate or 0
+
+	for row in doc.sales_team:
+		row.allocated_amount = commission_rate
+		allocated_percentage = row.allocated_percentage or 0
+		row.incentives = round((commission_rate * allocated_percentage) / 100, 2)

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -160,11 +160,15 @@ doc_events = {
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_expense"
 		],
-		"on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.on_submit",
-		"before_save":[
-			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+		"on_submit": [
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.on_submit",
 			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team",
-		]
+
+		],
+		"before_save":[
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team",
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+		],
 	},
 	"Payment Entry" : {
 		"on_submit" : "e_mart.e_mart.custom_scripts.payment_entry.payment_entry.update_down_payment_status"

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -161,7 +161,10 @@ doc_events = {
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_expense"
 		],
 		"on_submit": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.on_submit",
-		"before_save": "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+		"before_save":[
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team",
+		]
 	},
 	"Payment Entry" : {
 		"on_submit" : "e_mart.e_mart.custom_scripts.payment_entry.payment_entry.update_down_payment_status"

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -19,6 +19,7 @@ def after_install():
 	create_custom_fields(get_sales_invoice_custom_fields(), ignore_validate=True, update=True)
 	create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
 	create_custom_fields(get_mode_of_payment_custom_fields(), ignore_validate=True, update=True)
+	create_custom_fields(get_sales_order_custom_fields(),ignore_validate=True,update=True)
 
 	create_property_setters(get_property_setters())
 
@@ -39,6 +40,7 @@ def before_uninstall():
 	delete_custom_fields(get_sales_invoice_custom_fields())
 	delete_custom_fields(get_task_custom_fields())
 	delete_custom_fields(get_mode_of_payment_custom_fields())
+	delete_custom_fields(get_sales_order_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
 	"""
@@ -552,6 +554,27 @@ def get_sales_invoice_custom_fields():
 				"label": "Total Expense",
 				"read_only": 1,
 				"insert_after": "sales_expense_col"
-			}          
+			},
+			{
+				"fieldname": "total_commission_rate",
+				"fieldtype": "Currency",
+				"label": "Total Commission",
+				"insert_after": "items"
+			},
+		]
+	}
+
+def get_sales_order_custom_fields():
+	"""
+	Custom fields that need to be added to the Sales Order Item DocType
+	"""
+	return {
+		"Sales Order": [
+			{
+				"fieldname": "total_commission_rate",
+				"fieldtype": "Currency",
+				"label": "Total Commission",
+				"insert_after": "items"
+			},
 		]
 	}


### PR DESCRIPTION
Feature description
Calculate incentives on commission

Solution description
created field in sales invoice and sales order called (commission rate)
fetch the commission rate value to sales team child table in sales invoice
incentives calculated based on commission rate/contribution

Output screenshots (optional)
![Screenshot from 2025-07-09 17-14-12](https://github.com/user-attachments/assets/1d5a221e-7a96-461b-99de-eef341c8150e)
