### PR TITLE
fix : Avoided set timeout from the code

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -295,20 +295,17 @@ function calculate_total_expense(frm) {
 	frm.set_value('total_expense', total);
 }
 
-// calculate incentives based on commission rate and allocated percentage
 frappe.ui.form.on("Sales Team", {
 	allocated_percentage: function(frm, cdt, cdn) {
-		setTimeout(function() {
 			var sales_person = frappe.get_doc(cdt, cdn);
 			let row = locals[cdt][cdn];
 			if (sales_person.allocated_percentage) {
 				sales_person.allocated_percentage = sales_person.allocated_percentage;
-				sales_person.allocated_amount = frm.doc.total_commission_rate;
-				sales_person.incentives = flt(
-					(sales_person.allocated_amount * row.allocated_percentage) / 100.0,
+				sales_person.total_commission_rate = frm.doc.total_commission_rate;
+				sales_person.incentive = flt(
+					(sales_person.total_commission_rate * row.allocated_percentage) / 100.0,
 				);
 				frm.refresh_field('sales_team');
 			}
-		}, 20);
 	}
 });

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -372,6 +372,7 @@ def map_commission_to_sales_team(doc, method):
 	commission_rate = doc.total_commission_rate or 0
 
 	for row in doc.sales_team:
-		row.allocated_amount = commission_rate
+		row.total_commission_rate = commission_rate
 		allocated_percentage = row.allocated_percentage or 0
-		row.incentives = round((commission_rate * allocated_percentage) / 100, 2)
+		row.incentive = round((commission_rate * allocated_percentage) / 100, 2)
+

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -20,6 +20,7 @@ def after_install():
 	create_custom_fields(get_task_custom_fields(), ignore_validate=True, update=True)
 	create_custom_fields(get_mode_of_payment_custom_fields(), ignore_validate=True, update=True)
 	create_custom_fields(get_sales_order_custom_fields(),ignore_validate=True,update=True)
+	create_custom_fields(get_sales_team_custom_fields(),ignore_validate=True,update=True)
 
 	create_property_setters(get_property_setters())
 
@@ -41,6 +42,7 @@ def before_uninstall():
 	delete_custom_fields(get_task_custom_fields())
 	delete_custom_fields(get_mode_of_payment_custom_fields())
 	delete_custom_fields(get_sales_order_custom_fields())
+	delete_custom_fields(get_sales_team_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
 	"""
@@ -379,7 +381,22 @@ def get_property_setters():
 			"field_name": "grant_commission",
 			"property": "hidden",
 			"value": 1
-		}
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Sales Team",
+			"field_name": "allocated_amount",
+			"property": "hidden",
+			"value": 1
+		},
+		{
+			"doctype_or_field": "DocField",
+			"doc_type": "Sales Team",
+			"field_name": "incentives",
+			"property": "hidden",
+			"value": 1
+		},
+
 	]
 def get_sales_invoice_custom_fields():
 	"""
@@ -575,6 +592,27 @@ def get_sales_order_custom_fields():
 				"fieldtype": "Currency",
 				"label": "Total Commission",
 				"insert_after": "items"
+			},
+		]
+	}
+
+def get_sales_team_custom_fields():
+	"""
+	Custom fields that need to be added to the Sales Team DocType
+	"""
+	return {
+		"Sales Team": [
+			{
+				"fieldname": "total_commission_rate",
+				"fieldtype": "Currency",
+				"label": "Total Commission",
+				"insert_after": "contact_no"
+			},
+			{
+				"fieldname": "incentive",
+				"fieldtype": "Currency",
+				"label": "Incentive",
+				"insert_after": "total_commission_rate"
 			},
 		]
 	}


### PR DESCRIPTION
## Feature description
Calculation of incentives based on commission rate
## Solution description
using property setter hide the field allocated_amount and incentives
Created Doctype Batta Policy 
## Output
![Screenshot from 2025-07-10 14-37-15](https://github.com/user-attachments/assets/0242d7c5-be9d-4e9c-a473-c925dae79ddc)

## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Chrome
