### PR TITLE
feat : customize sales invoice and mapped to finance invoice

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -200,6 +200,18 @@ function set_finance_filter(frm) {
 		}
 	});
 
+	frm.set_query("emi_provider", () => {
+		if (frm.doc.sales_type === "EMI") {
+			return {
+				filters: {
+					is_provider: 1
+				}
+			};
+		} else {
+			return {};
+		}
+	});
+
 	if (frm.doc.sales_type === "EMI" && frm.doc.customer) {
 		frappe.db.get_value("Customer", frm.doc.customer, "is_provider", (r) => {
 			if (r && r.is_provider !== 1) {

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -124,10 +124,10 @@ def create_finance_invoice(sales_invoice_name):
 	sales_invoice = frappe.get_doc("Sales Invoice", sales_invoice_name)
 
 	finance_invoice = frappe.new_doc("Finance Invoice")
-	finance_invoice.customer = sales_invoice.customer
+	finance_invoice.customer = sales_invoice.emi_provider
 	finance_invoice.posting_date = frappe.utils.nowdate()
 	finance_invoice.total_amount = sales_invoice.total
-	finance_invoice.actual_customer = sales_invoice.actual_customer
+	finance_invoice.actual_customer = sales_invoice.customer
 	finance_invoice.total_taxes_and_charges = sales_invoice.total_taxes_and_charges
 
 	for item in sales_invoice.items:

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -578,6 +578,14 @@ def get_sales_invoice_custom_fields():
 				"label": "Total Commission",
 				"insert_after": "items"
 			},
+			{
+				"fieldname": "emi_provider",
+				"fieldtype": "Link",
+				"options": "Customer",
+				"label": "EMI Provider",
+				"insert_after": "sales_type",
+				"depends_on": "eval:doc.sales_type == 'EMI'"
+			},
 		]
 	}
 


### PR DESCRIPTION
Feature description
Added a field called EMI Provider in sales invoice

Solution description

When sales type is EMI, EMI Provider field will appear.
Added a filter in EMI Provider based on customer doctype is provider is checked
Mapped EMI provider and customer in finance invoice

Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-07-10 16-38-23" src="https://github.com/user-attachments/assets/ddc462c8-e9e7-4595-8e55-a5ba61006591" />
<img width="1366" height="768" alt="Screenshot from 2025-07-10 16-37-55" src="https://github.com/user-attachments/assets/a580f2df-9c0c-4ee0-bf02-c1dc8be1e4cb" />

Is there any existing behaviour change of other features due to this code change?
No

Was this feature tested on the browsers?
Chrome