### PR TITLE
fix:Updated the EMI amount after deducting the down payment from outstanding amount

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -247,12 +247,13 @@ function set_finance_filter(frm) {
  * and updates the emi_amount field immediately.
  */
 function update_emi_amount(frm) {
-	let down_payment = frm.doc.down_payment_amount || 0;
-	let total = frm.doc.total || 0;
-	let emi_amount = total - down_payment;
+    const down_payment = flt(frm.doc.down_payment_amount || 0);
+    const outstanding = flt(frm.doc.outstanding_amount || 0);
+    const emi_amount = outstanding - down_payment;
 
-	frm.set_value('emi_amount', emi_amount);
+    frm.set_value('emi_amount', Math.max(emi_amount, 0));
 }
+
 
 /**
  * Generates EMI Duration child table rows dynamically

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -2,6 +2,9 @@ import frappe
 from frappe.utils import flt,add_months,nowdate,get_first_day,get_last_day,add_days
 from frappe.model.mapper import get_mapped_doc
 from datetime import datetime
+from frappe.utils import flt
+from frappe.utils import get_url_to_form
+
 
 def on_submit(doc, method=None):
 	create_scrap_stock_entry(doc, method)
@@ -82,9 +85,9 @@ def update_emi_amount(doc, method):
 	"""
 	Generate the emi amount after deducting the down payment
 	"""
-	down_payment = doc.down_payment_amount or 0
-	total = doc.total or 0
-	doc.emi_amount = total - down_payment
+	down_payment = flt(doc.down_payment_amount)
+	outstanding = flt(doc.outstanding_amount)
+	doc.emi_amount = outstanding - down_payment
 
 def generate_emi_schedule(doc, method):
 	"""
@@ -317,7 +320,7 @@ def update_monthly_commission_log(doc, method):
 
 	for sales_team_member in doc.sales_team:
 		sales_person = sales_team_member.sales_person
-		incentives = sales_team_member.incentives or 0
+		incentives = sales_team_member.incentive or 0
 
 		# Get the Employee linked to Sales Person
 		employee = frappe.db.get_value("Sales Person", sales_person, "employee")
@@ -357,6 +360,12 @@ def update_monthly_commission_log(doc, method):
 		})
 
 		log.save(ignore_permissions=True)
+		link = get_url_to_form("Monthly Commission Log", log.name)
+		frappe.msgprint(
+			f'Monthly Commission Log Created/Updated: <a href="{link}" target="_blank"><b>{log.name}</b></a>',
+			alert=True,
+			indicator='green'
+		)
 
 def calculate_total_expense(doc, method):
 	"""

--- a/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.json
+++ b/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.json
@@ -19,12 +19,14 @@
   {
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date"
+   "label": "Start Date",
+   "read_only": 1
   },
   {
    "fieldname": "end_date",
    "fieldtype": "Date",
-   "label": "End Date"
+   "label": "End Date",
+   "read_only": 1
   },
   {
    "fieldname": "log_month",
@@ -40,7 +42,8 @@
    "fieldname": "monthly_commission_log",
    "fieldtype": "Table",
    "label": "Monthly Commission Log Detail",
-   "options": "Monthly Commission Logs"
+   "options": "Monthly Commission Logs",
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",
@@ -56,7 +59,8 @@
    "fieldname": "employee",
    "fieldtype": "Link",
    "label": "Employee",
-   "options": "Employee"
+   "options": "Employee",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_wwtu",
@@ -67,7 +71,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-04 12:23:09.522388",
+ "modified": "2025-07-11 13:26:21.020253",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "Monthly Commission Log",

--- a/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.json
+++ b/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.json
@@ -39,6 +39,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "monthly_commission_log",
    "fieldtype": "Table",
    "label": "Monthly Commission Log Detail",
@@ -71,7 +72,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-11 13:26:21.020253",
+ "modified": "2025-07-14 10:18:32.833165",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "Monthly Commission Log",

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -167,8 +167,7 @@ doc_events = {
 
 		],
 		"before_save":[
-			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team",
-			# "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team"
 		],
 	},
 	"Payment Entry" : {

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -158,7 +158,8 @@ doc_events = {
 		"validate":[
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule",
-			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_expense"
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_expense",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount"
 		],
 		"on_submit": [
 			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.on_submit",
@@ -167,7 +168,7 @@ doc_events = {
 		],
 		"before_save":[
 			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.map_commission_to_sales_team",
-			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
+			# "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
 		],
 	},
 	"Payment Entry" : {

--- a/e_mart/setup.py
+++ b/e_mart/setup.py
@@ -481,7 +481,8 @@ def get_sales_invoice_custom_fields():
 				"fieldname": "emi_amount",
 				"fieldtype": "Currency",
 				"label": "EMI AMOUNT",
-				"insert_after": "down_payment_amount"
+				"insert_after": "down_payment_amount",
+				"read_only": 1
 			},
 			{
 				"fieldname": "emi_date",
@@ -520,7 +521,8 @@ def get_sales_invoice_custom_fields():
 				"fieldtype": "Table",
 				"label": "EMI Schedule",
 				"options":"EMI Duration",
-				"insert_after": "emi_duration_section"
+				"insert_after": "emi_duration_section",
+				"read_only": 1
 			},
 			{
 				"fieldname": "down_payment",
@@ -540,7 +542,8 @@ def get_sales_invoice_custom_fields():
 				"fieldname": "closing_date",
 				"fieldtype": "Date",
 				"label": "Closing Date",
-				"insert_after": "no_of_installment"
+				"insert_after": "no_of_installment",
+				"read_only": 1
 			},
 			{
 				"fieldname": "sales_expense_tab",


### PR DESCRIPTION
## Feature description
Need to: 
- Update the EMI amount after deducting the down payment from outstanding amount instead of total in sales invoice doctype
- Set EMI amount ,closing date and EMI Schedule table in Emi details in sales invoice doctype  are readonly
- Set Employee ,Start Date,End Date and Monthly Commission Log Detail field in monthly commision log doctype are readonly
-  Show Message with Link After Monthly Commission Log Creation

## Solution description
- Updated the EMI amount after deducting the down payment from outstanding amount instead of total in sales invoice doctype 
- Set EMI amount ,closing date and EMI Schedule table in Emi details in sales invoice doctype  are readonly
- Set Employee ,Start Date,End Date and Monthly Commission Log Detail field in monthly commision log doctype are readonly
- Show Message with Link After Monthly Commission Log Creation


## Output screenshots (optional)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3dfdea51-f0e0-4219-81fa-25240190034e" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cae26371-fa0e-403f-a2e7-b016a3142c8e" />

[Screencast from 11-07-25 04:25:50 PM IST.webm](https://github.com/user-attachments/assets/4beb5e4f-8da8-418c-afa8-f4761363058c)


## Areas affected and ensured
 Sales invoice doctype 
## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

