### PR TITLE
fix : purchase schema is invoice-level user input should be saved

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -2,37 +2,36 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Purchase Invoice', {
-    onload: function(frm) {
-        let previous_length = frm.doc.items ? frm.doc.items.length : 0;
+	onload: function(frm) {
+		let previous_length = frm.doc.items ? frm.doc.items.length : 0;
 
-        frm.fields_dict.items.grid.wrapper.on('click', function() {
-            setTimeout(() => {
-                let current_length = frm.doc.items ? frm.doc.items.length : 0;
-                if (current_length !== previous_length) {
-                    update_schema_discount_amount_total(frm);
-                    previous_length = current_length;
-                }
-            }, 150);
-        });
-    }
+		frm.fields_dict.items.grid.wrapper.on('click', function() {
+			setTimeout(() => {
+				let current_length = frm.doc.items ? frm.doc.items.length : 0;
+				if (current_length !== previous_length) {
+					update_schema_discount_amount_total(frm);
+					previous_length = current_length;
+				}
+			}, 150);
+		});
+	}
 });
 
 frappe.ui.form.on('Purchase Invoice Item', {
-    schema_discount_amount: function(frm) {
-        update_schema_discount_amount_total(frm);
-    }
+	schema_discount_amount: function(frm) {
+		update_schema_discount_amount_total(frm);
+	}
 });
 
 /**
  * function to calculate the total of schema discount amount from items table
  */
 function update_schema_discount_amount_total(frm) {
-    let total = 0;
-    (frm.doc.items || []).forEach(row => {
-        if (row.schema_discount_amount) {
-            total += row.schema_discount_amount;
-        }
-    });
-    frm.set_value('schema_discount_amount', total);
+	let total = 0;
+	(frm.doc.items || []).forEach(row => {
+		if (row.schema_discount_amount) {
+			total += row.schema_discount_amount;
+		}
+	});
+	frm.set_value('schema_discount_amount', total);
 }
-

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -5,15 +5,16 @@ import frappe
 
 def update_schema_discount_amount(doc, method):
     """
-    Updates the parent schema_discount_amount field with the sum of all child schema_discount_amount values.
+    Updates schema_discount_amount in the parent document during validate:
+    - If purchase_schema == "item-wise", calculate total from child rows.
+    - If purchase_schema == "invoice-level", keep user-entered value.
     """
-    total_schema_discount = 0
+    if doc.purchase_schema == "item-wise":
+        total_schema_discount = 0
+        for item in doc.items:
+            total_schema_discount += item.schema_discount_amount or 0
 
-    for item in doc.items:
-        if item.schema_discount_amount:
-            total_schema_discount += item.schema_discount_amount
-
-    doc.schema_discount_amount = total_schema_discount
+        doc.schema_discount_amount = total_schema_discount
 
 def on_submit(doc, method):
     create_debit_note_log(doc)

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -239,20 +239,20 @@ def create_buyback_journal_entry(doc, method):
 	journal_entry.company = company
 	journal_entry.remark = f"Buyback adjustment for Sales Invoice {doc.name}"
 
-	# Debit Customer (receivable)
+	# Credit Customer (receivable)
 	journal_entry.append("accounts", {
 		"account": customer_account,
 		"party_type": "Customer",
 		"party": doc.customer,
-		"debit_in_account_currency": doc.buyback_amount,
+		"credit_in_account_currency": doc.buyback_amount,
 		"reference_type": "Sales Invoice",
 		"reference_name": doc.name
 	})
 
-	# Credit Buyback Posting Account
+	# Dedit Buyback Posting Account
 	journal_entry.append("accounts", {
 		"account": buyback_account,
-		"credit_in_account_currency": doc.buyback_amount
+		"debit_in_account_currency": doc.buyback_amount
 	})
 
 	journal_entry.insert(ignore_permissions=True)


### PR DESCRIPTION
 Feature description
 purchase schema is invoice-level user input should be saved

Solution description
-  purchase schema is invoice-level user input should be saved in schema discount amount
-  purchase schema is item-level schema discount amount must be calculated from item child table field (schema discount amount )
Output screenshots (optional)
<img width="1366" height="768" alt="Screenshot from 2025-07-15 21-16-09" src="https://github.com/user-attachments/assets/6e824c7c-43e6-47ba-8c37-b37039cc0a02" />

Is there any existing behaviour change of other features due to this code change?
No

Was this feature tested on the browsers?
Chrome