### PR TITLE
TASK-2025-01665:Calculated profit for commission for each item based on total expense and contribution

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -41,8 +41,8 @@ frappe.ui.form.on('Sales Invoice', {
 			}, __('Create'));
 		}
 	}
-	calculate_total_expense(frm);
-},
+	    calculate_total_expense(frm);
+	},
 	sales_type(frm) {
 		set_finance_filter(frm);
 	},
@@ -84,6 +84,7 @@ frappe.ui.form.on('Sales Invoice', {
 		update_emi_amount(frm);
 		generate_emi_schedule(frm);
 		calculate_total_expense(frm);
+        update_profit_for_commission(frm);
 	},
 	calculate_totals(frm) {
 		setTimeout(() => {
@@ -92,6 +93,9 @@ frappe.ui.form.on('Sales Invoice', {
 			calculate_total_expense(frm);
 		}, 200);
 	},
+    total_expense(frm) {
+		update_profit_for_commission(frm);
+	}
 });
 // Buyback Item child table
 frappe.ui.form.on('Buyback Item', {
@@ -115,13 +119,29 @@ frappe.ui.form.on('Sales Invoice Item', {
 	},
 	amount(frm) {
 		frm.trigger("calculate_totals");
+		calculate_total_expense(frm);
 	},
 	items_add(frm) {
 		frm.trigger("calculate_totals");
 	},
 	items_remove(frm) {
 		frm.trigger("calculate_totals");
-	}
+	},
+	item_code(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        if (row.item_code) {
+            frappe.db.get_value("Item", row.item_code, "sales_expense_contribution")
+            .then(r => {
+                if (r.message) {
+                    frappe.model.set_value(cdt, cdn, "sales_expense_contribution", r.message.sales_expense_contribution);
+                    update_profit_for_commission(frm);
+                    }
+                });
+            }
+    },
+	sales_expense_contribution(frm, cdt, cdn) {
+        update_profit_for_commission(frm);
+    }
 });
 
 // Taxes child table
@@ -331,6 +351,7 @@ function calculate_total_expense(frm) {
 		total += flt(row.amount || 0);
 	});
 	frm.set_value('total_expense', total);
+	update_profit_for_commission(frm);
 }
 
 frappe.ui.form.on("Sales Team", {
@@ -347,3 +368,20 @@ frappe.ui.form.on("Sales Team", {
 			}
 	}
 });
+
+/**
+ * Calculates the profit for Commission for each item by subtracting its Sales Expense Contribution
+ * from the total expense.
+ */
+function update_profit_for_commission(frm) {
+	const total_expense = flt(frm.doc.total_expense || 0);
+
+	(frm.doc.items || []).forEach(row => {
+		const contribution = flt(row.sales_expense_contribution || 0);
+		const profit = total_expense - contribution;
+		// Set profit_for_commission for each item
+		frappe.model.set_value(row.doctype, row.name, 'profit_for_commission', profit);
+	});
+
+	frm.refresh_field('items');
+}

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -387,3 +387,12 @@ def map_commission_to_sales_team(doc, method):
 		allocated_percentage = row.allocated_percentage or 0
 		row.incentive = round((commission_rate * allocated_percentage) / 100, 2)
 
+def calculate_profit_for_commission(doc, method):
+	"""Calculates profit for commission for each item by subtracting its Sales Expense Contribution from the total expense."""
+	total_expense = flt(doc.total_expense or 0)
+
+	for item in doc.items:
+		contribution = flt(item.sales_expense_contribution or 0)
+		profit = total_expense - contribution
+		item.profit_for_commission = profit
+

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -157,8 +157,9 @@ doc_events = {
 	"Sales Invoice": {
 		"validate":[
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_buyback_fields",
-			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_expense",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_profit_for_commission",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.generate_emi_schedule",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount"
 		],
 		"on_submit": [


### PR DESCRIPTION
## Feature description
Need to: 
- Fetch Sales expense contribution in Sales invoice item from item.
- Calculate profit for commission based on sales expense contribution and total expense amount.

## Solution description

- Fetch Sales expense contribution in Sales invoice item from item.
- Calculated profit for commission based on sales expense contribution and total expense amount.


## Output screenshots (optional)
[Screencast from 15-07-25 05:43:31 PM IST.webm](https://github.com/user-attachments/assets/d8583b49-9956-4ce5-af4e-be0bc3112a7e)

## Areas affected and ensured
 Sales invoice doctype 
## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

