### PR TITLE
fix:Prevented duplicate Payment Entry creation for down payment

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -32,15 +32,15 @@ frappe.ui.form.on('Sales Invoice', {
 					}
 				});
 			});
-		if (frm.doc.docstatus === 1 && frm.doc.down_payment && frm.doc.down_payment_amount) {
-			frm.add_custom_button(__('Down Payment'), function() {
-				frappe.model.open_mapped_doc({
-					method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.make_down_payment_entry",
-					source_name: frm.doc.name  
-				});
-			}, __('Create'));
-		}
-	}
+            if (frm.doc.docstatus === 1 && frm.doc.down_payment && frm.doc.down_payment_amount && frm.doc.down_payment_paid == 0 ) {
+                frm.add_custom_button(__('Down Payment'), function() {
+                    frappe.model.open_mapped_doc({
+                        method: "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.make_down_payment_entry",
+                        source_name: frm.doc.name
+                    });
+                }, __('Create'));
+            }
+        }
 	    calculate_total_expense(frm);
 	},
 	sales_type(frm) {


### PR DESCRIPTION
## Feature description
Need to: 

- Prevent duplicate Payment Entry creation for down payment

## Solution description
- Prevented duplicate Payment Entry creation for down payment

## Output screenshots (optional)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f688a088-07bc-4294-85ab-193991443e75" />


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b83237ee-c383-4d77-bc49-f487c3df1898" />


## Areas affected and ensured
 Sales invoice doctype 
## Is there any existing behaviour change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

