### PR TITLE
fix: use Additional Salary Component from E-mart Settings for commission

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -255,14 +255,6 @@ function set_finance_filter(frm) {
 			return {};
 		}
 	});
-
-	if (frm.doc.docstatus === 0 && frm.doc.sales_type === "EMI" && frm.doc.customer) {
-		frappe.db.get_value("Customer", frm.doc.customer, "is_provider", (r) => {
-			if (r && r.is_provider !== 1) {
-				frm.set_value("customer", null);
-			}
-		});
-	}
 }
 
 /**

--- a/e_mart/e_mart/doctype/debit_note_log/debit_note_log.json
+++ b/e_mart/e_mart/doctype/debit_note_log/debit_note_log.json
@@ -35,6 +35,7 @@
    "in_list_view": 1,
    "label": "Supplier",
    "options": "Supplier",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -45,13 +46,15 @@
    "fieldname": "purchase_invoice",
    "fieldtype": "Link",
    "label": "Purchase Invoice",
-   "options": "Purchase Invoice"
+   "options": "Purchase Invoice",
+   "read_only": 1
   },
   {
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Pending\nSubmitted\nRejected\nCancelled"
+   "options": "Pending\nSubmitted\nRejected\nCancelled",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_omvk",
@@ -72,7 +75,8 @@
    "fieldname": "jv_reference",
    "fieldtype": "Link",
    "label": "JV Reference",
-   "options": "Journal Entry"
+   "options": "Journal Entry",
+   "read_only": 1
   },
   {
    "fieldname": "supplier_credit_note_no",
@@ -90,24 +94,28 @@
   {
    "fieldname": "total_invoice_amount",
    "fieldtype": "Currency",
-   "label": "Total Invoice Amount"
+   "label": "Total Invoice Amount",
+   "read_only": 1
   },
   {
    "fieldname": "discounted_amount",
    "fieldtype": "Currency",
-   "label": "Discounted Amount"
+   "label": "Discounted Amount",
+   "read_only": 1
   },
   {
    "fieldname": "items",
    "fieldtype": "Table",
    "label": "Items",
-   "options": "Debit Note Item"
+   "options": "Debit Note Item",
+   "read_only": 1
   },
   {
    "fieldname": "purchase_schema",
    "fieldtype": "Select",
    "label": "Purchase Schema",
-   "options": "Item-wise\nInvoice-level"
+   "options": "Item-wise\nInvoice-level",
+   "read_only": 1
   },
   {
    "collapsible": 1,
@@ -148,7 +156,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-27 12:28:32.656273",
+ "modified": "2025-07-23 14:31:18.839508",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "Debit Note Log",
@@ -168,6 +176,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
+++ b/e_mart/e_mart/doctype/e_mart_settings/e_mart_settings.json
@@ -12,6 +12,8 @@
   "scrap_warehouse",
   "column_break_bgwq",
   "buyback_posting_account",
+  "column_break_aixl",
+  "additional_salary_component",
   "demo_schedule_details_tab",
   "subject",
   "task_type",
@@ -85,13 +87,23 @@
    "fieldtype": "Link",
    "label": "Buyback Posting Account",
    "options": "Account"
+  },
+  {
+   "fieldname": "column_break_aixl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "additional_salary_component",
+   "fieldtype": "Link",
+   "label": "Additional Salary Component",
+   "options": "Salary Component"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-04 10:39:11.057244",
+ "modified": "2025-07-23 12:40:56.440831",
  "modified_by": "Administrator",
  "module": "E Mart",
  "name": "E-mart Settings",
@@ -108,6 +120,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
+++ b/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
@@ -24,15 +24,15 @@ def create_additional_salary_from_commission(log_name):
 	)
 
 	total_incentive = sum(row.incentives for row in log.monthly_commission_log if row.incentives)
-	settings = frappe.get_single("E-mart Settings")
-	if not settings.additional_salary_component:
+	salary_component = frappe.db.get_single_value("E-mart Settings", "additional_salary_component")
+	if not salary_component:
 		frappe.throw("Additional Salary Component is not set in E-mart Settings.")
 
 	doc = frappe.get_doc({
 		"doctype": "Additional Salary",
 		"employee": log.employee,
 		"company": frappe.defaults.get_user_default("company"),
-		"salary_component": settings.additional_salary_component,
+		"salary_component": salary_component,
 		"amount": total_incentive,
 		"payroll_date": latest_date,
 		"overwrite_salary_structure_amount": 1

--- a/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
+++ b/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
@@ -24,12 +24,15 @@ def create_additional_salary_from_commission(log_name):
 	)
 
 	total_incentive = sum(row.incentives for row in log.monthly_commission_log if row.incentives)
+	settings = frappe.get_single("E-mart Settings")
+	if not settings.additional_salary_component:
+		frappe.throw("Additional Salary Component is not set in E-mart Settings.")
 
 	doc = frappe.get_doc({
 		"doctype": "Additional Salary",
 		"employee": log.employee,
 		"company": frappe.defaults.get_user_default("company"),
-		"salary_component": "Incentive",
+		"salary_component": settings.additional_salary_component,
 		"amount": total_incentive,
 		"payroll_date": latest_date,
 		"overwrite_salary_structure_amount": 1

--- a/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
+++ b/e_mart/e_mart/doctype/monthly_commission_log/monthly_commission_log.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.utils import getdate
+from frappe import _
 from frappe.model.document import Document
 
 class MonthlyCommissionLog(Document):
@@ -26,7 +27,7 @@ def create_additional_salary_from_commission(log_name):
 	total_incentive = sum(row.incentives for row in log.monthly_commission_log if row.incentives)
 	salary_component = frappe.db.get_single_value("E-mart Settings", "additional_salary_component")
 	if not salary_component:
-		frappe.throw("Additional Salary Component is not set in E-mart Settings.")
+		frappe.throw(_("Please set the Additional Salary Component in E-mart Settings before proceeding."),title=_("Configuration Required"))
 
 	doc = frappe.get_doc({
 		"doctype": "Additional Salary",


### PR DESCRIPTION
## Feature description
- Add Additional salary component in E-mart settings.
- Use additional salary component from E-mart settings for commission.
- Update Debit Note Log doctype.

## Solution description
- Added additional salary component in E-mart Settings.
- Fetched additional salary component from E-mart Settings for commission.
- Made fields to read only in debit note log.
- Removed is provider filter from customer in sales invoice.

## Output screenshots (optional)
<img width="1262" height="631" alt="image" src="https://github.com/user-attachments/assets/fd05990e-1c05-4957-ad4d-73a9c5ac8fff" />
<img width="1262" height="631" alt="image" src="https://github.com/user-attachments/assets/b5bcd499-c4f2-496e-a468-bf5fbfe9216c" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox