### PR TITLE
fix: Prevent creation of Debit Note Log when schema discount amount is zero

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.py
@@ -23,6 +23,8 @@ def create_debit_note_log(purchase_invoice):
 	'''
 		Creates a Debit Note Log from a submitted Purchase Invoice
 	'''
+	if not purchase_invoice.schema_discount_amount or purchase_invoice.schema_discount_amount == 0:
+		return
 	exists = frappe.db.exists("Debit Note Log", {"purchase_invoice": purchase_invoice.name})
 	if exists:
 		frappe.msgprint(f"Debit Note Log already exists for {purchase_invoice.name}")


### PR DESCRIPTION
## Feature description
- Prevent creation of Debit Note Log when schema discount amount is zero.

## Solution description
- Prevented creation of Debit Note Log when schema discount amount is zero.

## Output screenshots (optional)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/9fd95d45-20d0-4135-b029-64b211bdd522" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/70c3f497-2498-42a6-924e-3a19290ca3b8" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox