### PR TITLE
chore: Remove update emi amount from the function of calculating outstanding amount in sales invoice.

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -231,7 +231,6 @@ function update_outstanding_amount(frm) {
 		}
 		frm.set_value('outstanding_amount', Math.max(outstanding, 0));
 		update_grand_total(frm); 
-		update_emi_amount(frm);
 	}
 }
 


### PR DESCRIPTION
## Feature description
- Remove update emi amount from the function of calculating outstanding amount in sales invoice.

## Solution description
- Removed update emi amount from the function of calculating outstanding amount in sales invoice.Because emi amount is calculated in child table.

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox