### PR TITLE
refactor: Update grand total,outstanding amount and rounded total for buyback amount.

### DIFF
--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Sales Invoice', {
 				}
 			};
 		});
-		set_finance_filter(frm);+
+		set_finance_filter(frm);
 		attach_sales_expense_grid_events(frm);
 		calculate_total_expense(frm);
 		calculate_total_down_payment(frm);

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.js
@@ -5,7 +5,6 @@ frappe.ui.form.on('Sales Invoice', {
 	onload(frm) {
 		frm.fields_dict.buyback_items.grid.wrapper.on('change', function () {
 			update_total_buyback_amount(frm);
-			update_rounded_total(frm);
 		});
 		frm.set_query('item', 'buyback_items', function(doc, cdt, cdn) {
 			return {
@@ -14,7 +13,7 @@ frappe.ui.form.on('Sales Invoice', {
 				}
 			};
 		});
-		set_finance_filter(frm);
+		set_finance_filter(frm);+
 		attach_sales_expense_grid_events(frm);
 		calculate_total_expense(frm);
 		calculate_total_down_payment(frm);
@@ -63,36 +62,28 @@ frappe.ui.form.on('Sales Invoice', {
 		sync_sales_type_to_items(frm);
 	},
 	total: function(frm) {
-		update_outstanding_amount(frm);
-		update_rounded_total(frm);
+		update_grand_total(frm);
 	},
-	total_taxes_and_charges(frm) {
-		update_outstanding_amount(frm);
-		update_rounded_total(frm);
-	},
-
 	buyback_amount(frm) {
-		update_outstanding_amount(frm);
-		update_rounded_total(frm);
+		update_grand_total(frm);
 	},
 
 	is_buyback(frm) {
-		update_outstanding_amount(frm);
-		update_rounded_total(frm);
+		update_grand_total(frm);
 	},
 	validate(frm) {
 		calculate_total_expense(frm);
 		update_profit_for_commission(frm);
 		calculate_total_down_payment(frm);
 		calculate_total_emi_amount(frm);
+        update_grand_total(frm);
 	},
 	calculate_totals(frm) {
 		setTimeout(() => {
-			update_outstanding_amount(frm);
-			update_rounded_total(frm);
 			calculate_total_expense(frm);
 			calculate_total_down_payment(frm);
 			calculate_total_emi_amount(frm);
+            update_grand_total(frm);
 		}, 200);
 	},
 	total_expense(frm) {
@@ -107,17 +98,16 @@ frappe.ui.form.on('Buyback Item', {
 	rate(frm, cdt, cdn) {
 		calculate_row_amount(frm, cdt, cdn);
 	},
+    amount(frm, cdt, cdn) {
+        update_total_buyback_amount(frm);
+    },
 	buyback_items_add(frm) {
 		update_total_buyback_amount(frm);
-		update_grand_total(frm);
-		update_rounded_total(frm);
-		update_outstanding_amount(frm)
+        update_grand_total(frm);
 	},
 	buyback_items_remove(frm) {
 		update_total_buyback_amount(frm);
-		update_grand_total(frm);
-		update_rounded_total(frm);
-		update_outstanding_amount(frm)
+        update_grand_total(frm);
 	}
 });
 // Sales Invoice Items child table
@@ -128,6 +118,22 @@ frappe.ui.form.on('Sales Invoice Item', {
 		set_valuation_and_gross_profit(frm, cdt, cdn);
 	},
 	rate(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        if (row.item_code && row.rate) {
+            frappe.db.get_value("Item", row.item_code, "mrp")
+                .then(r => {
+                    if (r.message && r.message.mrp) {
+                        let mrp = flt(r.message.mrp);
+                        if (flt(row.rate) > mrp) {
+                            frappe.msgprint({ 
+                                message: __('Rate cannot be greater than MRP ({0})', [mrp]),
+                                indicator: 'red'
+                            });
+                            frappe.model.set_value(cdt, cdn, "rate", mrp);
+                        }
+                    }
+                });
+        }
 		frm.trigger("calculate_totals");
 		update_emi_amount(frm, cdt, cdn);
 		set_valuation_and_gross_profit(frm, cdt, cdn);
@@ -211,57 +217,6 @@ function update_total_buyback_amount(frm) {
 		total += flt(row.amount || 0);
 	});
 	frm.set_value('buyback_amount', total);
-	update_outstanding_amount(frm);
-	update_rounded_total(frm);
-	update_grand_total(frm);
-}
-
-/*
-* Calculate Outstanding Amount based on buyback amount
-*/
-function update_outstanding_amount(frm) {
-	if (frm.doc.docstatus === 0) { 
-		const total = flt(frm.doc.total || 0);
-		const taxes = flt(frm.doc.total_taxes_and_charges || 0);
-		const buyback = flt(frm.doc.buyback_amount || 0);
-
-		let outstanding = total + taxes;
-		if (frm.doc.is_buyback) {
-			outstanding -= buyback;
-		}
-		frm.set_value('outstanding_amount', Math.max(outstanding, 0));
-		update_grand_total(frm); 
-	}
-}
-
-/*
-* Calculate Rounded Total based on buyback amount
-*/
-function update_rounded_total(frm) {
-	const total = flt(frm.doc.total || 0);
-	const taxes = flt(frm.doc.total_taxes_and_charges || 0);
-	const buyback = flt(frm.doc.buyback_amount || 0);
-
-	let grand_total = total + taxes;
-	if (frm.doc.is_buyback) {
-		grand_total -= buyback;
-	}
-	frm.set_value('rounded_total', Math.round(grand_total));
-}
-
-/*
-* Calculate Grand Total based on buyback amount
-*/
-function update_grand_total(frm) {
-	const total = flt(frm.doc.total || 0);
-	const taxes = flt(frm.doc.total_taxes_and_charges || 0);
-	const buyback = flt(frm.doc.buyback_amount || 0);
-
-	let grand_total = total + taxes;
-	if (frm.doc.is_buyback) {
-		grand_total -= buyback;
-	}
-	frm.set_value('grand_total', grand_total);
 }
 
 // Filter customer field to show only providers when sales_type is EMI
@@ -591,4 +546,23 @@ function show_payment_popup(frm) {
 		}, 100);
 	});
 	update_balance();
+}
+
+/**
+* Updates grand total,rounded total and outstanding amount for buyback amount
+*/
+function update_grand_total(frm) {
+    setTimeout(() => {
+        let grand_total = flt(frm.doc.grand_total || 0);
+        let buyback_amount = flt(frm.doc.buyback_amount || 0);
+        if (frm.doc.is_buyback) {
+            let adjusted_total = grand_total - buyback_amount;
+            frm.set_value('grand_total', adjusted_total);
+            frm.set_value('rounded_total', Math.round(adjusted_total));
+            frm.set_value(
+                'outstanding_amount',
+                Math.max(adjusted_total - flt(frm.doc.total_advance || 0), 0)
+            );
+        }
+    }, 500);
 }

--- a/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
+++ b/e_mart/e_mart/custom_scripts/sales_invoice/sales_invoice.py
@@ -15,40 +15,6 @@ def on_submit(doc, method=None):
 	create_demo_tasks_on_submit(doc, method)
 	update_monthly_commission_log(doc, method)
 
-def validate_buyback_fields(doc, method=None):
-	"""
-	Triggered on validation of Sales Invoice.
-
-	1. Calculates amount for each Buyback Item row.
-	2. Sums up all row amounts into buyback_amount.
-	3. Adjusts the outstanding_amount, rounded total and grand total if is_buyback check box is checked
-	"""
-
-	total = 0
-
-	# 1. Calculate amount per row
-	if doc.buyback_items:
-		for row in doc.buyback_items:
-			row.amount = (row.qty or 0) * (row.rate or 0)
-			total += row.amount
-
-	# 2. Set total buyback amount
-	doc.buyback_amount = total
-
-	# 3.Calculate outstanding amount
-	grand_total = (doc.total or 0) + (doc.total_taxes_and_charges or 0)
-	if doc.is_buyback and doc.buyback_amount:
-		grand_total -= doc.buyback_amount
-	doc.outstanding_amount = round(grand_total)
-
-	# 4. Set rounded_total and Grand Total
-	grand_total = (doc.total or 0) + (doc.total_taxes_and_charges or 0)
-	if doc.is_buyback and doc.buyback_amount:
-		grand_total -= doc.buyback_amount
-	doc.grand_total = grand_total
-	doc.outstanding_amount = round(grand_total)
-	doc.rounded_total = round(grand_total)
-
 def create_scrap_stock_entry(doc, method):
 	"""
 	On submission of Sales Invoice:
@@ -514,3 +480,30 @@ def make_payment_entry(sales_invoice, payments):
 		frappe.throw("No valid payments found.")
 
 	return ", ".join(created_entries)
+
+def validate_mrp_and_rate(doc, method):
+	"""
+	Validate that the rate of each item in the Sales Invoice does not exceed its MRP.
+	"""
+	for row in doc.items:
+		if row.item_code and row.rate:
+			mrp = frappe.db.get_value("Item", row.item_code, "mrp")
+			if mrp and row.rate > mrp:
+				frappe.throw(
+					_("Rate of item {0} ({1}) cannot be greater than its MRP ({2})")
+					.format(row.item_code, row.rate, mrp)
+				)
+
+def validate_buyback_fields(doc, method=None):
+	"""
+	Adjust Sales Invoice totals for buyback.
+	"""
+	base_total = flt(doc.grand_total or 0)
+	adjusted_total = base_total
+
+	if doc.is_buyback:
+		adjusted_total -= flt(doc.buyback_amount or 0)
+
+	doc.grand_total = adjusted_total
+	doc.rounded_total = round(adjusted_total)
+	doc.outstanding_amount = max(adjusted_total - flt(doc.total_advance or 0), 0)

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -161,7 +161,8 @@ doc_events = {
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_profit_for_commission",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.update_emi_amount",
 			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_down_payment",
-			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_emi_amount"
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.calculate_total_emi_amount",
+			  "e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.validate_mrp_and_rate"
 		],
 		"on_submit": [
 			"e_mart.e_mart.custom_scripts.sales_invoice.sales_invoice.on_submit",


### PR DESCRIPTION
## Feature description
- Update calculation of grand total,rounded total and outstanding amount for buyback amount.
- Validate rate of sales invoice item when it is greater than that of mrp of that item.

## Solution description
- Updated calculation of grand total,rounded total and outstanding amount for buyback amount.
- Validated rate of sales invoice item when it is greater than that of mrp of that item.
- Removed calculation of outstanding amount,grand total and rounded total from sales invoice because the calculation is not worked properly

## Output screenshots (optional)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d9706500-b5b5-44ae-ab59-71b6241b2d11" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/c8be357b-9432-447e-80dc-3b36ff0830c2" />

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox