### PR TITLE
feat: Clear taxes and recalculates totals when the purchase category is set to 'Special'

### DIFF
--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -15,39 +15,14 @@ frappe.ui.form.on('Purchase Invoice', {
 			}, 150);
 		});
 	},
-	//clears taxes and recalculates totals when Purchase Category is set to "Special"
 	purchase_category: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-			
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
-			
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	},
 	validate: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	}
 });
@@ -85,4 +60,24 @@ function calculate_total_schema_discount(cdt, cdn) {
 		row.total_schema_discount = row.qty * row.schema_discount_amount;
 		frappe.model.set_value(cdt, cdn, 'total_schema_discount_amount', row.total_schema_discount);
 	}
+}
+
+/**
+ * Clears taxes and recalculates total when purchase category is set to 'Special'
+ */
+function clear_special_taxes(frm) {
+	frm.set_value('taxes_and_charges', null);
+	frm.clear_table('taxes');
+	frm.refresh_field('taxes');
+
+	frm.doc.total_taxes_and_charges = 0;
+	frm.doc.taxes_and_charges_added = 0;
+	frm.doc.grand_total = frm.doc.net_total || 0;
+	frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+	frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+
+	frm.refresh_field('total_taxes_and_charges');
+	frm.refresh_field('grand_total');
+	frm.refresh_field('rounded_total');
+	frm.refresh_field('outstanding_amount');
 }

--- a/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice/purchase_invoice.js
@@ -14,6 +14,41 @@ frappe.ui.form.on('Purchase Invoice', {
 				}
 			}, 150);
 		});
+	},
+	//clears taxes and recalculates totals when Purchase Category is set to "Special"
+	purchase_category: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+			
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+			
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
+	},
+	validate: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
 	}
 });
 
@@ -51,4 +86,3 @@ function calculate_total_schema_discount(cdt, cdn) {
 		frappe.model.set_value(cdt, cdn, 'total_schema_discount_amount', row.total_schema_discount);
 	}
 }
-		

--- a/e_mart/e_mart/custom_scripts/purchase_invoice_dashboard/purchase_invoice_dashboard.py
+++ b/e_mart/e_mart/custom_scripts/purchase_invoice_dashboard/purchase_invoice_dashboard.py
@@ -1,14 +1,29 @@
 from frappe import _
 
 def get_data(data=None):
-    return {
-        "fieldname": "purchase_invoice",  
-        "non_standard_fieldnames": {
-            "Debit Note Log": "purchase_invoice"
-        },
-        "transactions": [
-            {
-                "items": ["Debit Note Log"]
-            }
-        ]
-    }
+	return {
+		"fieldname": "purchase_invoice",
+		"non_standard_fieldnames": {
+			"Journal Entry": "reference_name",
+			"Payment Entry": "reference_name",
+			"Payment Request": "reference_name",
+			"Landed Cost Voucher": "receipt_document",
+			"Purchase Invoice": "return_against",
+			"Auto Repeat": "reference_document",
+			"Debit Note Log": "purchase_invoice"
+		},
+		"internal_links": {
+			"Purchase Order": ["items", "purchase_order"],
+			"Purchase Receipt": ["items", "purchase_receipt"],
+		},
+		"transactions": [
+			{"label": _("Payment"), "items": ["Payment Entry", "Payment Request", "Journal Entry"]},
+			{
+				"label": _("Reference"),
+				"items": ["Purchase Order", "Purchase Receipt", "Asset", "Landed Cost Voucher"],
+			},
+			{"label": _("Returns"), "items": ["Purchase Invoice"]},
+			{"label": _("Subscription"), "items": ["Auto Repeat"]},
+			{"label": _("Debit Note"), "items": ["Debit Note Log"]}, 
+		],
+	}

--- a/e_mart/e_mart/custom_scripts/purchase_order/purchase_order.js
+++ b/e_mart/e_mart/custom_scripts/purchase_order/purchase_order.js
@@ -1,0 +1,37 @@
+frappe.ui.form.on('Purchase Order', {
+	//clears taxes and recalculates totals when Purchase Category is set to "Special"
+	purchase_category: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+			
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+			
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
+	},
+	validate: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
+	}
+});

--- a/e_mart/e_mart/custom_scripts/purchase_order/purchase_order.js
+++ b/e_mart/e_mart/custom_scripts/purchase_order/purchase_order.js
@@ -1,37 +1,32 @@
 frappe.ui.form.on('Purchase Order', {
-	//clears taxes and recalculates totals when Purchase Category is set to "Special"
 	purchase_category: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-			
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
-			
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	},
 	validate: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	}
 });
+
+/**
+ * Clears taxes and recalculates total when purchase category is set to 'Special'
+ */
+function clear_special_taxes(frm) {
+	frm.set_value('taxes_and_charges', null);
+	frm.clear_table('taxes');
+	frm.refresh_field('taxes');
+
+	frm.doc.total_taxes_and_charges = 0;
+	frm.doc.taxes_and_charges_added = 0;
+	frm.doc.grand_total = frm.doc.net_total || 0;
+	frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+	frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+
+	frm.refresh_field('total_taxes_and_charges');
+	frm.refresh_field('grand_total');
+	frm.refresh_field('rounded_total');
+	frm.refresh_field('outstanding_amount');
+}

--- a/e_mart/e_mart/custom_scripts/purchase_receipt/purchase_receipt.js
+++ b/e_mart/e_mart/custom_scripts/purchase_receipt/purchase_receipt.js
@@ -1,0 +1,37 @@
+frappe.ui.form.on('Purchase Receipt', {
+	//clears taxes and recalculates totals when Purchase Category is set to "Special"
+	purchase_category: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+			
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+			
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
+	},
+	validate: function(frm) {
+		if (frm.doc.purchase_category === 'Special') {
+			frm.set_value('taxes_and_charges', null);
+			frm.clear_table('taxes');
+			frm.refresh_field('taxes');
+
+			frm.doc.total_taxes_and_charges = 0;
+			frm.doc.taxes_and_charges_added = 0;
+			frm.doc.grand_total = frm.doc.net_total || 0;
+			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+
+			frm.refresh_field('total_taxes_and_charges');
+			frm.refresh_field('grand_total');
+			frm.refresh_field('rounded_total');
+		}
+	}
+});

--- a/e_mart/e_mart/custom_scripts/purchase_receipt/purchase_receipt.js
+++ b/e_mart/e_mart/custom_scripts/purchase_receipt/purchase_receipt.js
@@ -1,37 +1,32 @@
 frappe.ui.form.on('Purchase Receipt', {
-	//clears taxes and recalculates totals when Purchase Category is set to "Special"
 	purchase_category: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-			
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-			frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
-			
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	},
 	validate: function(frm) {
 		if (frm.doc.purchase_category === 'Special') {
-			frm.set_value('taxes_and_charges', null);
-			frm.clear_table('taxes');
-			frm.refresh_field('taxes');
-
-			frm.doc.total_taxes_and_charges = 0;
-			frm.doc.taxes_and_charges_added = 0;
-			frm.doc.grand_total = frm.doc.net_total || 0;
-			frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
-
-			frm.refresh_field('total_taxes_and_charges');
-			frm.refresh_field('grand_total');
-			frm.refresh_field('rounded_total');
+			clear_special_taxes(frm);
 		}
 	}
 });
+
+/**
+ * Clears taxes and recalculates total when purchase category is set to 'Special'
+ */
+function clear_special_taxes(frm) {
+	frm.set_value('taxes_and_charges', null);
+	frm.clear_table('taxes');
+	frm.refresh_field('taxes');
+
+	frm.doc.total_taxes_and_charges = 0;
+	frm.doc.taxes_and_charges_added = 0;
+	frm.doc.grand_total = frm.doc.net_total || 0;
+	frm.doc.rounded_total = Math.round(frm.doc.grand_total || 0);
+	frm.doc.outstanding_amount = frm.doc.rounded_total || 0;
+
+	frm.refresh_field('total_taxes_and_charges');
+	frm.refresh_field('grand_total');
+	frm.refresh_field('rounded_total');
+	frm.refresh_field('outstanding_amount');
+}

--- a/e_mart/hooks.py
+++ b/e_mart/hooks.py
@@ -45,7 +45,9 @@ app_include_js = "/assets/e_mart/js/sales_invoice.js"
 # include js in doctype views
 doctype_js = {
 	"Purchase Invoice" : "e_mart/custom_scripts/purchase_invoice/purchase_invoice.js",
-	"Sales Invoice" : "e_mart/custom_scripts/sales_invoice/sales_invoice.js"
+	"Sales Invoice" : "e_mart/custom_scripts/sales_invoice/sales_invoice.js",
+	"Purchase Order": "e_mart/custom_scripts/purchase_order/purchase_order.js",
+	"Purchase Receipt": "e_mart/custom_scripts/purchase_receipt/purchase_receipt.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}


### PR DESCRIPTION
## Feature description
- Clear taxes and recalculates totals in purchase order,receipt and invoice when the purchase category is set to 'Special'
- Add connections in purchase invoice.

## Solution description
- Clears taxes and recalculates totals in purchase order,receipt and invoice when the purchase category is set to 'Special'
- Added connections in purchase invoice.

## Output screenshots (optional)
<img width="1348" height="608" alt="image" src="https://github.com/user-attachments/assets/46e59e60-8c34-4009-b12b-e57788b29eed" />
[Screencast from 23-08-25 10:38:03 AM IST.webm](https://github.com/user-attachments/assets/7795e8fa-c567-4757-b9bd-4ea324fb8169)

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Mozilla Firefox